### PR TITLE
Add parameterized tests

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -10,6 +10,7 @@ Criterion
     assert
     hooks
     env
+    parameterized
     theories
     internal
     faq

--- a/doc/parameterized.rst
+++ b/doc/parameterized.rst
@@ -1,0 +1,110 @@
+Using parameterized tests
+=========================
+
+Parameterized tests are useful to repeat a specific test logic over a finite
+set of parameters.
+
+Due to limitations on how generated parameters are passed, parameterized tests
+can only accept one pointer parameter; however, this is not that much of a
+problem since you can just pass a structure containing the context you need.
+
+Adding parameterized tests
+--------------------------
+
+Adding parameterized tests is done by defining the parameterized test function,
+and the parameter generator function:
+
+.. code-block:: c
+
+    #include <criterion/parameterized.h>
+
+    ParameterizedTestParameter(suite_name, test_name) = {
+        void *params;
+        size_t nb_params;
+
+        // generate parameter set
+        return cr_make_param_array(Type, params, nb_params);
+    }
+
+    ParameterizedTest(Type *param, suite_name, test_name) {
+        // contents of the test
+    }
+
+``suite_name`` and ``test_name`` are the identifiers of the test suite and
+the test, respectively. These identifiers must follow the language
+identifier format.
+
+``Type`` is the compound type of the generated array. ``params`` and ``nb_params``
+are the pointer and the length of the generated array, respectively.
+
+Passing multiple parameters
+---------------------------
+
+As said earlier, parameterized tests only take one parameter, so passing
+multiple parameters is, in the strict sense, not possible. However, one can
+easily use a struct to hold the context as a workaround:
+
+.. code-block:: c
+
+    #include <criterion/parameterized.h>
+
+    struct my_params {
+        int param0;
+        double param1;
+        ...
+    };
+
+    ParameterizedTestParameter(suite_name, test_name) = {
+        size_t nb_params = 32;
+        struct my_params *params = malloc(sizeof (struct my_params) * nb_params);
+
+        // generate parameter set
+
+        params[0] = ...
+        params[1] = ...
+
+        ...
+
+        return cr_make_param_array(struct my_params, params, nb_params);
+    }
+
+    ParameterizedTest(struct my_params *param, suite_name, test_name) {
+        // access param.param0, param.param1, ...
+    }
+
+There is, however, one absolute rule that must be respected, unless you don't
+want your tests to run on windows, ever: parameters must not contain any
+pointer to dynamically allocated data.
+
+Hence, this is not permitted:
+
+.. code-block:: c
+
+    #include <criterion/parameterized.h>
+
+    struct my_params {
+        int *some_int_ptr;
+    };
+
+    ParameterizedTestParameter(suite_name, test_name) = {
+        static my_params param = {
+            .some_int_ptr = malloc(sizeof (int)); // Don't do this.
+        };
+        *param.some_int_ptr = 42;
+
+        return cr_make_param_array(struct my_params, &param, 1);
+    }
+
+and **will crash the test** on Windows.
+
+Configuring parameterized tests
+-------------------------------
+
+Parameterized tests can optionally recieve configuration parameters to alter
+their own behaviour, and are applied to each iteration of the parameterized
+test individually (this means that the initialization and finalization runs once
+per iteration).
+Those parameters are the same ones as the ones of the ``Test`` macro function
+(c.f. :ref:`test-config-ref`).
+
+

--- a/include/criterion/criterion.h
+++ b/include/criterion/criterion.h
@@ -48,6 +48,8 @@
     TEST_PROTOTYPE_(Category, Name);                                           \
     struct criterion_test_extra_data IDENTIFIER_(Category, Name, extra) =      \
         CR_EXPAND(CRITERION_MAKE_STRUCT(struct criterion_test_extra_data,      \
+            .kind_ = CR_TEST_NORMAL,                                           \
+            .param_ = (struct criterion_test_params(*)(void)) NULL,            \
             .identifier_ = #Category "/" #Name,                                \
             .file_    = __FILE__,                                              \
             .line_    = __LINE__,                                              \

--- a/include/criterion/parameterized.h
+++ b/include/criterion/parameterized.h
@@ -1,0 +1,48 @@
+#ifndef CRITERION_PARAMETERIZED_H_
+# define CRITERION_PARAMETERIZED_H_
+
+# include "criterion.h"
+
+# ifdef __cplusplus
+#  define CR_PARAM_TEST_PROTOTYPE_(Param, Category, Name) \
+    extern "C" void IDENTIFIER_(Category, Name, impl)(Param)
+# else
+#  define CR_PARAM_TEST_PROTOTYPE_(Param, Category, Name) \
+    void IDENTIFIER_(Category, Name, impl)(Param)
+# endif
+
+# define ParameterizedTest(...) \
+    CR_EXPAND(ParameterizedTest_(__VA_ARGS__, .sentinel_ = 0))
+
+# define ParameterizedTest_(Param, Category, Name, ...)                        \
+    CR_PARAM_TEST_PROTOTYPE_(Param, Category, Name);                           \
+    struct criterion_test_extra_data IDENTIFIER_(Category, Name, extra) =      \
+        CR_EXPAND(CRITERION_MAKE_STRUCT(struct criterion_test_extra_data,      \
+            .kind_ = CR_TEST_PARAMETERIZED,                                    \
+            .param_ = IDENTIFIER_(Category, Name, param),                      \
+            .identifier_ = #Category "/" #Name,                                \
+            .file_    = __FILE__,                                              \
+            .line_    = __LINE__,                                              \
+            __VA_ARGS__                                                        \
+        ));                                                                    \
+    SECTION_("cr_tst")                                                         \
+    struct criterion_test IDENTIFIER_(Category, Name, meta) = {                \
+        #Name,                                                                 \
+        #Category,                                                             \
+        (void(*)(void)) IDENTIFIER_(Category, Name, impl),                     \
+        &IDENTIFIER_(Category, Name, extra)                                    \
+    } SECTION_SUFFIX_;                                                         \
+    CR_PARAM_TEST_PROTOTYPE_(Param, Category, Name)
+
+# define ParameterizedTestParameters(Category, Name) \
+    static struct criterion_test_params IDENTIFIER_(Category, Name, param)(void)
+
+# ifdef __cplusplus
+#  define cr_make_param_array(Type, Array, Length) \
+    criterion_test_params(sizeof (Type), (Array), (Length))
+# else
+#  define cr_make_param_array(Type, Array, Length) \
+    (struct criterion_test_params) { sizeof (Type), (void**)(Array), (Length) }
+# endif
+
+#endif /* !CRITERION_PARAMETERIZED_H_ */

--- a/include/criterion/parameterized.h
+++ b/include/criterion/parameterized.h
@@ -42,7 +42,7 @@
     criterion_test_params(sizeof (Type), (Array), (Length))
 # else
 #  define cr_make_param_array(Type, Array, Length) \
-    (struct criterion_test_params) { sizeof (Type), (void**)(Array), (Length) }
+    (struct criterion_test_params) { sizeof (Type), (void*)(Array), (Length) }
 # endif
 
 #endif /* !CRITERION_PARAMETERIZED_H_ */

--- a/include/criterion/parameterized.h
+++ b/include/criterion/parameterized.h
@@ -38,11 +38,11 @@
     static struct criterion_test_params IDENTIFIER_(Category, Name, param)(void)
 
 # ifdef __cplusplus
-#  define cr_make_param_array(Type, Array, Length) \
-    criterion_test_params(sizeof (Type), (Array), (Length))
+#  define cr_make_param_array(Type, Array, ...) \
+    criterion_test_params(sizeof (Type), (Array), __VA_ARGS__)
 # else
-#  define cr_make_param_array(Type, Array, Length) \
-    (struct criterion_test_params) { sizeof (Type), (void*)(Array), (Length) }
+#  define cr_make_param_array(Type, Array, ...) \
+    (struct criterion_test_params) { sizeof (Type), (void*)(Array), __VA_ARGS__ }
 # endif
 
 #endif /* !CRITERION_PARAMETERIZED_H_ */

--- a/include/criterion/parameterized.h
+++ b/include/criterion/parameterized.h
@@ -42,7 +42,7 @@
     criterion_test_params(sizeof (Type), (Array), __VA_ARGS__)
 # else
 #  define cr_make_param_array(Type, Array, ...) \
-    (struct criterion_test_params) { sizeof (Type), (void*)(Array), __VA_ARGS__ }
+    (struct criterion_test_params) { .size = sizeof (Type), (void*)(Array), __VA_ARGS__ }
 # endif
 
 #endif /* !CRITERION_PARAMETERIZED_H_ */

--- a/include/criterion/parameterized.h
+++ b/include/criterion/parameterized.h
@@ -25,13 +25,15 @@
             .line_    = __LINE__,                                              \
             __VA_ARGS__                                                        \
         ));                                                                    \
-    SECTION_("cr_tst")                                                         \
     struct criterion_test IDENTIFIER_(Category, Name, meta) = {                \
         #Name,                                                                 \
         #Category,                                                             \
         (void(*)(void)) IDENTIFIER_(Category, Name, impl),                     \
         &IDENTIFIER_(Category, Name, extra)                                    \
-    } SECTION_SUFFIX_;                                                         \
+    };                                                                         \
+    SECTION_("cr_tst")                                                         \
+    struct criterion_test *IDENTIFIER_(Category, Name, ptr)                    \
+            = &IDENTIFIER_(Category, Name, meta) SECTION_SUFFIX_;              \
     CR_PARAM_TEST_PROTOTYPE_(Param, Category, Name)
 
 # define ParameterizedTestParameters(Category, Name) \

--- a/include/criterion/types.h
+++ b/include/criterion/types.h
@@ -42,12 +42,21 @@ struct criterion_test_params {
     size_t size;
     void *params;
     size_t length;
+    void (*cleanup)(struct criterion_test_params *);
 
 # ifdef __cplusplus
     constexpr criterion_test_params(size_t size, void *params, size_t length)
         : size(size)
         , params(params)
         , length(length)
+    {}
+
+    constexpr criterion_test_params(size_t size, void *params, size_t length,
+            void (*cleanup)(struct criterion_test_params *))
+        : size(size)
+        , params(params)
+        , length(length)
+        , cleanup(cleanup)
     {}
 # endif
 };

--- a/include/criterion/types.h
+++ b/include/criterion/types.h
@@ -49,6 +49,7 @@ struct criterion_test_params {
         : size(size)
         , params(params)
         , length(length)
+        , cleanup(nullptr)
     {}
 
     constexpr criterion_test_params(size_t size, void *params, size_t length,

--- a/include/criterion/types.h
+++ b/include/criterion/types.h
@@ -40,11 +40,11 @@ enum criterion_test_kind {
 
 struct criterion_test_params {
     size_t size;
-    void **params;
+    void *params;
     size_t length;
 
 # ifdef __cplusplus
-    constexpr criterion_test_params(size_t size, void **params, size_t length)
+    constexpr criterion_test_params(size_t size, void *params, size_t length)
         : size(size)
         , params(params)
         , length(length)

--- a/include/criterion/types.h
+++ b/include/criterion/types.h
@@ -33,8 +33,29 @@ using std::size_t;
 # endif
 # include "common.h"
 
+enum criterion_test_kind {
+    CR_TEST_NORMAL,
+    CR_TEST_PARAMETERIZED,
+};
+
+struct criterion_test_params {
+    size_t size;
+    void **params;
+    size_t length;
+
+# ifdef __cplusplus
+    constexpr criterion_test_params(size_t size, void **params, size_t length)
+        : size(size)
+        , params(params)
+        , length(length)
+    {}
+# endif
+};
+
 struct criterion_test_extra_data {
     int sentinel_;
+    enum criterion_test_kind kind_;
+    struct criterion_test_params (*param_)(void);
     const char *identifier_;
     const char *file_;
     unsigned line_;

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SAMPLES
   theories.c
   timeout.c
   redirect.c
+  parameterized.c
 
   signal.cc
   report.cc

--- a/samples/outputs/parameterized.c.bin.err.expected
+++ b/samples/outputs/parameterized.c.bin.err.expected
@@ -1,0 +1,19 @@
+[[0;34m----[0m] [0;1mparameterized.c[0m:[0;31m60[0m: Assertion failed: Parameters: (1, 2.000000)
+[[0;31mFAIL[0m] params::cleanup: (0.00s)
+[[0;34m----[0m] [0;1mparameterized.c[0m:[0;31m60[0m: Assertion failed: Parameters: (3, 4.000000)
+[[0;31mFAIL[0m] params::cleanup: (0.00s)
+[[0;34m----[0m] [0;1mparameterized.c[0m:[0;31m60[0m: Assertion failed: Parameters: (5, 6.000000)
+[[0;31mFAIL[0m] params::cleanup: (0.00s)
+[[0;34m----[0m] [0;1mparameterized.c[0m:[0;31m36[0m: Assertion failed: Parameters: (1, 2.000000)
+[[0;31mFAIL[0m] params::multiple: (0.00s)
+[[0;34m----[0m] [0;1mparameterized.c[0m:[0;31m36[0m: Assertion failed: Parameters: (3, 4.000000)
+[[0;31mFAIL[0m] params::multiple: (0.00s)
+[[0;34m----[0m] [0;1mparameterized.c[0m:[0;31m36[0m: Assertion failed: Parameters: (5, 6.000000)
+[[0;31mFAIL[0m] params::multiple: (0.00s)
+[[0;34m----[0m] [0;1mparameterized.c[0m:[0;31m15[0m: Assertion failed: Parameter: foo
+[[0;31mFAIL[0m] params::str: (0.00s)
+[[0;34m----[0m] [0;1mparameterized.c[0m:[0;31m15[0m: Assertion failed: Parameter: bar
+[[0;31mFAIL[0m] params::str: (0.00s)
+[[0;34m----[0m] [0;1mparameterized.c[0m:[0;31m15[0m: Assertion failed: Parameter: baz
+[[0;31mFAIL[0m] params::str: (0.00s)
+[[0;34m====[0m] [0;1mSynthesis: Tested: [0;34m9[0;1m | Passing: [0;32m0[0;1m | Failing: [0;31m9[0;1m | Crashing: [0;31m0[0;1m [0m

--- a/samples/parameterized.c
+++ b/samples/parameterized.c
@@ -8,6 +8,6 @@ ParameterizedTestParameters(params, str) {
     return cr_make_param_array(const char *, strings, sizeof (strings) / sizeof (const char *));
 }
 
-ParameterizedTest(const char *str, params, str) {
-    cr_assert(0, "Parameter: %s", str);
+ParameterizedTest(const char **str, params, str) {
+    cr_assert(0, "Parameter: %s", *str);
 }

--- a/samples/parameterized.c
+++ b/samples/parameterized.c
@@ -42,33 +42,20 @@ ParameterizedTest(struct parameter_tuple *tup, params, multiple) {
 // or this will fail on windows
 
 void free_params(struct criterion_test_params *crp) {
-    struct parameter_tuple_dyn *tuples = crp->params;
-    for (size_t i = 0; i < crp->length; ++i) {
-        struct parameter_tuple_dyn *tup = &tuples[i];
-        free(tup->d);
-    }
     free(crp->params);
-}
-
-double *gen_double(double d) {
-    double *ptr = malloc(sizeof(double));
-    printf("%p\n", ptr);
-    fflush(NULL);
-    *ptr = d;
-    return ptr;
 }
 
 ParameterizedTestParameters(params, cleanup) {
     const size_t nb_tuples = 3;
 
-    struct parameter_tuple_dyn *params = malloc(sizeof(struct parameter_tuple_dyn) * nb_tuples);
-    params[0] = (struct parameter_tuple_dyn) { 1, gen_double(2) };
-    params[1] = (struct parameter_tuple_dyn) { 3, gen_double(4) };
-    params[2] = (struct parameter_tuple_dyn) { 5, gen_double(6) };
+    struct parameter_tuple *params = malloc(sizeof(struct parameter_tuple) * nb_tuples);
+    params[0] = (struct parameter_tuple) { 1, 2 };
+    params[1] = (struct parameter_tuple) { 3, 4 };
+    params[2] = (struct parameter_tuple) { 5, 6 };
 
-    return cr_make_param_array(struct parameter_tuple_dyn, params, nb_tuples, free_params);
+    return cr_make_param_array(struct parameter_tuple, params, nb_tuples, free_params);
 }
 
-ParameterizedTest(struct parameter_tuple_dyn *tup, params, cleanup) {
-    cr_assert_fail("Parameters: (%d, %p)", tup->i, tup->d);
+ParameterizedTest(struct parameter_tuple *tup, params, cleanup) {
+    cr_assert_fail("Parameters: (%d, %f)", tup->i, tup->d);
 }

--- a/samples/parameterized.c
+++ b/samples/parameterized.c
@@ -1,4 +1,7 @@
 #include <criterion/parameterized.h>
+#include <stdio.h>
+
+// Basic usage
 
 ParameterizedTestParameters(params, str) {
     static const char *strings[] = {
@@ -9,5 +12,63 @@ ParameterizedTestParameters(params, str) {
 }
 
 ParameterizedTest(const char **str, params, str) {
-    cr_assert(0, "Parameter: %s", *str);
+    cr_assert_fail("Parameter: %s", *str);
+}
+
+// Multiple parameters must be coalesced in a single parameter
+
+struct parameter_tuple {
+    int i;
+    double d;
+};
+
+ParameterizedTestParameters(params, multiple) {
+    static struct parameter_tuple params[] = {
+        {1, 2},
+        {3, 4},
+        {5, 6},
+    };
+
+    return cr_make_param_array(struct parameter_tuple, params, sizeof (params) / sizeof (struct parameter_tuple));
+}
+
+ParameterizedTest(struct parameter_tuple *tup, params, multiple) {
+    cr_assert_fail("Parameters: (%d, %f)", tup->i, tup->d);
+}
+
+// Cleaning up dynamically generated parameters
+
+// Note: Do **NOT** embed dynamically allocated pointers inside of structures
+// or this will fail on windows
+
+void free_params(struct criterion_test_params *crp) {
+    struct parameter_tuple_dyn *tuples = crp->params;
+    for (size_t i = 0; i < crp->length; ++i) {
+        struct parameter_tuple_dyn *tup = &tuples[i];
+        free(tup->d);
+    }
+    free(crp->params);
+}
+
+double *gen_double(double d) {
+    double *ptr = malloc(sizeof(double));
+    printf("%p\n", ptr);
+    fflush(NULL);
+    *ptr = d;
+    return ptr;
+}
+
+ParameterizedTestParameters(params, cleanup) {
+    const size_t nb_tuples = 3;
+
+    struct parameter_tuple_dyn *params = malloc(sizeof(struct parameter_tuple_dyn) * nb_tuples);
+    params[0] = (struct parameter_tuple_dyn) { 1, gen_double(2) };
+    params[1] = (struct parameter_tuple_dyn) { 3, gen_double(4) };
+    params[2] = (struct parameter_tuple_dyn) { 5, gen_double(6) };
+
+    return cr_make_param_array(struct parameter_tuple_dyn, params, nb_tuples, free_params);
+}
+
+ParameterizedTest(struct parameter_tuple_dyn *tup, params, cleanup) {
+    cr_assert_fail("Parameters: (%d, %p)", tup->i, tup->d);
 }

--- a/samples/parameterized.c
+++ b/samples/parameterized.c
@@ -1,0 +1,13 @@
+#include <criterion/parameterized.h>
+
+ParameterizedTestParameters(params, str) {
+    static const char *strings[] = {
+        "foo", "bar", "baz"
+    };
+
+    return cr_make_param_array(const char *, strings, sizeof (strings) / sizeof (const char *));
+}
+
+ParameterizedTest(const char *str, params, str) {
+    cr_assert(0, "Parameter: %s", str);
+}

--- a/src/compat/process.c
+++ b/src/compat/process.c
@@ -290,7 +290,17 @@ s_proc_handle *fork_process() {
     ResumeThread(info.hThread);
     CloseHandle(info.hThread);
 
-    while (!ctx->resumed); // wait until the child has initialized itself
+    // wait until the child has initialized itself
+    while (!ctx->resumed) {
+        DWORD exit;
+        GetExitCodeProcess(info.hProcess, &exit);
+        if (exit != STILL_ACTIVE) {
+            UnmapViewOfFile(ctx);
+            CloseHandle(sharedMem);
+            CloseHandle(info.hProcess);
+            return (void *) -1;
+        }
+    }
 
     UnmapViewOfFile(ctx);
     CloseHandle(sharedMem);

--- a/src/compat/process.c
+++ b/src/compat/process.c
@@ -297,13 +297,13 @@ s_proc_handle *fork_process() {
     if (g_worker_context.suite->data)
         ctx->suite_data = *g_worker_context.suite->data;
 
-    if (ResumeThread(info.hThread) == -1)
+    if (ResumeThread(info.hThread) == (DWORD) -1)
         goto failure;
 
     // wait until the child has initialized itself
     while (!ctx->resumed) {
         DWORD exit;
-        if (!GetExitCodeProcess(info.hProcess, &exit));
+        if (!GetExitCodeProcess(info.hProcess, &exit))
             continue;
 
         if (exit != STILL_ACTIVE)

--- a/src/compat/process.h
+++ b/src/compat/process.h
@@ -42,6 +42,7 @@ struct worker_context {
     struct criterion_suite *suite;
     f_worker_func func;
     struct pipe_handle *pipe;
+    struct test_single_param *param;
 };
 
 extern struct worker_context g_worker_context;

--- a/src/core/runner.c
+++ b/src/core/runner.c
@@ -59,7 +59,6 @@ TestSuite();
 Test(,) {};
 
 static INLINE void nothing(void) {}
-static INLINE void nothing_ptr(UNUSED void* ptr) {}
 
 int cmp_suite(void *a, void *b) {
     struct criterion_suite *s1 = a, *s2 = b;
@@ -187,11 +186,14 @@ static void run_test_child(struct criterion_test *test,
     struct timespec_compat ts;
     if (!setjmp(g_pre_test)) {
         timer_start(&ts);
-        if (!test->data->param_)
-            (test->test ? test->test : nothing)();
-        else
-            (test->test ? (void(*)(void*)) test->test
-                        : nothing_ptr)(g_worker_context.param->ptr);
+        if (test->test) {
+            if (!test->data->param_) {
+                test->test();
+            } else {
+                void(*param_test_func)(void *) = (void(*)(void*)) test->test;
+                param_test_func(g_worker_context.param->ptr);
+            }
+        }
     }
 
     double elapsed_time;

--- a/src/core/runner.c
+++ b/src/core/runner.c
@@ -389,6 +389,10 @@ static void run_test_param(struct criterion_global_stats *stats,
         struct test_single_param param = { params.size, (char *) params.params + i * params.size };
 
         run_test(stats, suite_stats, test, suite, &param);
+        if (criterion_options.fail_fast && stats->tests_failed > 0)
+            break;
+        if (!is_runner())
+            break;
     }
 }
 

--- a/src/core/runner.c
+++ b/src/core/runner.c
@@ -386,7 +386,7 @@ static void run_test_param(struct criterion_global_stats *stats,
 
     struct criterion_test_params params = test->data->param_();
     for (size_t i = 0; i < params.length; ++i) {
-        struct test_single_param param = { params.size, params.params[i] };
+        struct test_single_param param = { params.size, (char *) params.params + i * params.size };
 
         run_test(stats, suite_stats, test, suite, &param);
     }

--- a/src/core/runner.c
+++ b/src/core/runner.c
@@ -396,6 +396,9 @@ static void run_test_param(struct criterion_global_stats *stats,
         if (!is_runner())
             break;
     }
+
+    if (params.cleanup)
+        params.cleanup(&params);
 }
 
 static void run_test_switch(struct criterion_global_stats *stats,

--- a/src/core/worker.c
+++ b/src/core/worker.c
@@ -77,12 +77,14 @@ void run_worker(struct worker_context *ctx) {
 struct process *spawn_test_worker(struct criterion_test *test,
                                   struct criterion_suite *suite,
                                   f_worker_func func,
-                                  s_pipe_handle *pipe) {
+                                  s_pipe_handle *pipe,
+                                  struct test_single_param *param) {
     g_worker_context = (struct worker_context) {
         .test = test,
         .suite = suite,
         .func = func,
-        .pipe = pipe
+        .pipe = pipe,
+        .param = param,
     };
 
     struct process *ptr = NULL;

--- a/src/core/worker.c
+++ b/src/core/worker.c
@@ -91,7 +91,7 @@ struct process *spawn_test_worker(struct criterion_test *test,
 
     s_proc_handle *proc = fork_process();
     if (proc == (void *) -1) {
-        return NULL;
+        abort();
     } else if (proc == NULL) {
         run_worker(&g_worker_context);
         return NULL;

--- a/src/core/worker.h
+++ b/src/core/worker.h
@@ -47,6 +47,11 @@ struct worker_status {
     struct process_status status;
 };
 
+struct test_single_param {
+    size_t size;
+    void *ptr;
+};
+
 void run_worker(struct worker_context *ctx);
 void set_runner_process(void);
 void unset_runner_process(void);
@@ -56,7 +61,8 @@ struct process_status get_status(int status);
 struct process *spawn_test_worker(struct criterion_test *test,
                                   struct criterion_suite *suite,
                                   f_worker_func func,
-                                  s_pipe_handle *pipe);
+                                  s_pipe_handle *pipe,
+                                  struct test_single_param *param);
 struct event *worker_read_event(struct process *proc);
 
 #endif /* !PROCESS_H_ */


### PR DESCRIPTION
From the original issue (#43):

From the discussion at https://github.com/Snaipe/Criterion/issues/40, a use-case has come to light:

>  [...] to implement parameterized tests, that would iterate over a user-generated dataset rather than the cartesian product of many datasets.

Also, this will run a separate test for each member of dataset and hence yield better result stats.

e.g. current approach is to enumerate over `TheoryDataSet` placeholder data array, which results in:

>
[====] Synthesis: Tested: 1 | Passing: 0 | Failing: 1 | Crashing: 0

for 1276 data items tested out of which (for example) only 26 are failing. 

With `ParameterizedTest` feature, we expect to get:

>
[====] Synthesis: Tested: 1276 | Passing: 1250 | Failing: 26 | Crashing: 0