### PR TITLE
Build: Improves preprocessor directives for BSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ add_subdirectory(dependencies/libcsptr/ EXCLUDE_FROM_ALL)
 add_subdirectory(dependencies/dyncall/ EXCLUDE_FROM_ALL)
 
 include_directories(
+  /usr/local/include/
   dependencies/libcsptr/include/
   dependencies/dyncall/dyncall/
 )


### PR DESCRIPTION
* Also adds a search path `/usr/local/include` to top-level CMakeLists.

Fixes #48.