### PR TITLE
Sometimes tests from only one compilation unit are registered

### DIFF
--- a/include/criterion/criterion.h
+++ b/include/criterion/criterion.h
@@ -53,13 +53,15 @@
             .line_    = __LINE__,                                              \
             __VA_ARGS__                                                        \
         ));                                                                    \
-    SECTION_("cr_tst")                                                         \
     struct criterion_test IDENTIFIER_(Category, Name, meta) = {                \
         #Name,                                                                 \
         #Category,                                                             \
         IDENTIFIER_(Category, Name, impl),                                     \
         &IDENTIFIER_(Category, Name, extra)                                    \
-    } SECTION_SUFFIX_;                                                         \
+    };                                                                         \
+    SECTION_("cr_tst")                                                         \
+    struct criterion_test *IDENTIFIER_(Category, Name, ptr)                    \
+            = &IDENTIFIER_(Category, Name, meta) SECTION_SUFFIX_;              \
     TEST_PROTOTYPE_(Category, Name)
 
 # define TestSuite(...) CR_EXPAND(TestSuite_(__VA_ARGS__, .sentinel_ = 0))
@@ -70,11 +72,13 @@
             .line_    = 0,                                                     \
             __VA_ARGS__                                                        \
         ));                                                                    \
-    SECTION_("cr_sts")                                                         \
     struct criterion_suite SUITE_IDENTIFIER_(Name, meta) = {                   \
         #Name,                                                                 \
         &SUITE_IDENTIFIER_(Name, extra),                                       \
-    } SECTION_SUFFIX_
+    };                                                                         \
+    SECTION_("cr_sts")                                                         \
+    struct criterion_suite *SUITE_IDENTIFIER_(Name, ptr)                       \
+	    = &SUITE_IDENTIFIER_(Name, meta) SECTION_SUFFIX_
 
 CR_BEGIN_C_API
 

--- a/src/runner.c
+++ b/src/runner.c
@@ -45,14 +45,14 @@
 #endif
 
 #ifdef _MSC_VER
-struct criterion_test  SECTION_START_(cr_tst);
-struct criterion_suite SECTION_START_(cr_sts);
-struct criterion_test  SECTION_END_(cr_tst);
-struct criterion_suite SECTION_END_(cr_sts);
+struct criterion_test  *SECTION_START_(cr_tst);
+struct criterion_suite *SECTION_START_(cr_sts);
+struct criterion_test  *SECTION_END_(cr_tst);
+struct criterion_suite *SECTION_END_(cr_sts);
 #endif
 
-IMPL_SECTION_LIMITS(struct criterion_test, cr_tst);
-IMPL_SECTION_LIMITS(struct criterion_suite, cr_sts);
+IMPL_SECTION_LIMITS(struct criterion_test*, cr_tst);
+IMPL_SECTION_LIMITS(struct criterion_suite*, cr_sts);
 
 // This is here to make the test suite & test sections non-empty
 TestSuite();
@@ -98,11 +98,11 @@ struct criterion_test_set *criterion_init(void) {
     struct criterion_ordered_set *suites = new_ordered_set(cmp_suite, dtor_suite_set);
 
     FOREACH_SUITE_SEC(s) {
-        if (!s->name)
-            break;
+        if (!*s)
+            continue;
 
         struct criterion_suite_set css = {
-            .suite = *s,
+            .suite = **s,
         };
         insert_ordered_set(suites, &css, sizeof (css));
     }
@@ -118,13 +118,13 @@ struct criterion_test_set *criterion_init(void) {
     };
 
     FOREACH_TEST_SEC(test) {
-        if (!test->category)
-            break;
-
-        if (!*test->category)
+        if (!*test)
             continue;
 
-        criterion_register_test(set, test);
+        if (!(*test)->category)
+            continue;
+
+        criterion_register_test(set, *test);
     }
 
     return set;

--- a/src/runner.h
+++ b/src/runner.h
@@ -27,19 +27,19 @@
 # include "criterion/types.h"
 # include "posix-compat.h"
 
-DECL_SECTION_LIMITS(struct criterion_test, cr_tst);
-DECL_SECTION_LIMITS(struct criterion_suite, cr_sts);
+DECL_SECTION_LIMITS(struct criterion_test*, cr_tst);
+DECL_SECTION_LIMITS(struct criterion_suite*, cr_sts);
 
 struct criterion_test_set *criterion_init(void);
 
 # define FOREACH_TEST_SEC(Test)                                         \
-    for (struct criterion_test *Test = GET_SECTION_START(cr_tst);       \
-            Test < (struct criterion_test*) GET_SECTION_END(cr_tst);    \
+    for (struct criterion_test **Test = GET_SECTION_START(cr_tst);      \
+            Test < (struct criterion_test**) GET_SECTION_END(cr_tst);   \
             ++Test)
 
 # define FOREACH_SUITE_SEC(Suite)                                       \
-    for (struct criterion_suite *Suite = GET_SECTION_START(cr_sts);     \
-            Suite < (struct criterion_suite*) GET_SECTION_END(cr_sts);  \
+    for (struct criterion_suite **Suite = GET_SECTION_START(cr_sts);    \
+            Suite < (struct criterion_suite**) GET_SECTION_END(cr_sts); \
             ++Suite)
 
 #endif /* !CRITERION_RUNNER_H_ */


### PR DESCRIPTION
I am able to reproduce this on my windows 10 setup.
Basically, this has to to with how the linker aligns the section entries and coalesce each section from all the compilation units into one.

This is pretty much a show stopper for any one having this issue.