### PR TITLE
Float eq/neq assertions are not accurate

### DIFF
--- a/.cmake/Modules/CheckFloatingPointFormat.c
+++ b/.cmake/Modules/CheckFloatingPointFormat.c
@@ -1,0 +1,47 @@
+// Originally taken from https://github.com/ntamas/unibinlog
+
+/* The MIT License (MIT)
+ *
+ * Copyright (c) 2014 Tamas Nepusz
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include <math.h>
+#include <stdio.h>
+#include <stdint.h>
+
+int main(void) {
+	const double numbers[8] = {
+		/* the IEEE-754 representation of the number below consists of the
+		 * first eight letters of the uppercase alphabet. Their order will
+		 * reveal the endianness we are dealing with. */
+		2.39373654120722785592079162598E6, 0, 0, 0,
+		/* these are just dummies */
+		1234567, 2345678, 3456789, 4567890 };
+	double result;
+	const double *ptr = numbers, *end = numbers + 8;
+
+	result = 0.0;
+	while (ptr < end) {
+		result += *ptr;
+		ptr++;
+	}
+
+	return (result == 12345.0);
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,16 @@ endif()
 
 # Find dependencies
 
+include(CheckFloatingPointFormat)
+
+UB_CHECK_FLOATING_POINT_FORMAT(HAVE_IEEE754_FLOATS
+    HAVE_FLOAT_BYTES_BIGENDIAN HAVE_FLOAT_WORDS_BIGENDIAN)
+
+if (NOT HAVE_IEEE754_FLOATS)
+    message(WARNING "This platform does not support IEEE 754 floats "
+        "-- advanced comparison on floating point datatypes will be disabled.")
+endif ()
+
 find_package(Gettext)
 find_package(Libintl)
 if (GETTEXT_FOUND AND LIBINTL_LIB_FOUND)
@@ -123,6 +133,10 @@ set(SOURCE_FILES
   src/entry/entry.c
 )
 
+if (HAVE_IEEE754_FLOATS)
+  set (SOURCE_FILES ${SOURCE_FILES} src/float/ieee754.c)
+endif ()
+
 if (PCRE_FOUND)
   set (SOURCE_FILES ${SOURCE_FILES}
     src/string/extmatch.c
@@ -163,6 +177,8 @@ target_link_libraries(criterion csptr dyncall_s)
 
 if (MSVC)
   target_link_libraries(criterion wingetopt)
+else ()
+  target_link_libraries(criterion m)
 endif ()
 
 if (HAVE_CLOCK_GETTIME)

--- a/include/criterion/float.h
+++ b/include/criterion/float.h
@@ -50,10 +50,20 @@ union criterion_fp_double {
 
 struct criterion_fp_any {
     unsigned long datasize;
-    union {
+    union inner {
         union criterion_fp_single sp;
         union criterion_fp_double dp;
+
+#ifdef __cplusplus
+        inner(float val) : sp {val} {}
+        inner(double val) : dp {val} {}
+#endif
     } val;
+
+#ifdef __cplusplus
+    criterion_fp_any(float val) : datasize(sizeof (float)), val(val) {}
+    criterion_fp_any(double val) : datasize(sizeof (double)), val(val) {}
+#endif
 };
 
 CR_BEGIN_C_API

--- a/include/criterion/float.h
+++ b/include/criterion/float.h
@@ -30,8 +30,8 @@
 // This is part of the ABI, do **not** reorder or remove entries.
 // Add new entries at the end, but before CR_FP_CMP_NB_STRATEGIES_.
 enum criterion_fpcmp_strategy {
-    CR_FP_CMP_RELATIVE_EPSILON,
     CR_FP_CMP_ABSOLUTE_EPSILON,
+    CR_FP_CMP_RELATIVE_EPSILON,
     CR_FP_CMP_ULPS,
     CR_FP_CMP_ADAPTIVE,
 

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -3,6 +3,7 @@
 
 #cmakedefine ENABLE_NLS @ENABLE_NLS@
 #cmakedefine HAVE_PCRE @HAVE_PCRE@
+#cmakedefine HAVE_IEEE754_FLOATS @HAVE_IEEE754_FLOATS@
 
 # define LOCALEDIR "${LOCALEDIR}"
 # define PACKAGE "${PROJECT_NAME}"

--- a/src/entry/options.c
+++ b/src/entry/options.c
@@ -22,8 +22,14 @@
  * THE SOFTWARE.
  */
 # include "criterion/options.h"
+# include <float.h>
 
 struct criterion_options criterion_options = {
     .logging_threshold = CRITERION_IMPORTANT,
     .output_provider   = &normal_logging,
+    .floating_point_compare = {
+        .strategy = CR_FP_CMP_ABSOLUTE_EPSILON,
+        .flt_range = 4,
+        .flt_epsilon = FLT_EPSILON,
+    },
 };

--- a/src/float/ieee754.c
+++ b/src/float/ieee754.c
@@ -1,0 +1,159 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright © 2015 Franklin "Snaipe" Mathieu <http://snai.pe/>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include "config.h"
+
+#ifndef HAVE_IEEE754_FLOATS
+# error IEEE 754 floats are not supported on this platform.
+#endif
+
+#define _GNU_SOURCE 1
+#include <assert.h>
+#include <stdlib.h>
+#include <float.h>
+#include <math.h>
+#include "criterion/float.h"
+#include "criterion/options.h"
+#include "common.h"
+
+static const union criterion_fp_single single_min = { .f = FLT_MIN };
+static const union criterion_fp_single single_neg_min = { .f = -FLT_MIN };
+
+static INLINE int32_t abs32(int32_t x) {
+    return x < 0 ? -x : x;
+}
+
+static INLINE int64_t abs64(int64_t x) {
+    return x < 0 ? -x : x;
+}
+
+#ifdef __GNUC__
+# define likely(x)   __builtin_expect((x),1)
+# define unlikely(x) __builtin_expect((x),0)
+#else
+# define likely(x)
+# define unlikely(x)
+#endif
+
+#define fp_abs(Order) fp_abs_ ## Order
+#define fp_abs_single abs32
+#define fp_abs_double abs64
+
+#define fp_type(Order) fp_type_ ## Order
+#define fp_type_single float
+#define fp_type_double double
+
+#define fp_fabs(Order) fp_fabs_ ## Order
+#define fp_fabs_single fabsf
+#define fp_fabs_double fabs
+
+#define fpcmp_opt(Field) criterion_options.floating_point_compare. Field
+
+#define fp_range(Order) fpcmp_opt(fp_range_ ## Order)
+#define fp_range_single flt_range
+#define fp_range_double dbl_range
+
+#define fp_epsilon(Order) fpcmp_opt(fp_epsilon_ ## Order)
+#define fp_epsilon_single flt_epsilon
+#define fp_epsilon_double dbl_epsilon
+
+typedef int (*flt_cmp)(register union criterion_fp_single, register union criterion_fp_single);
+typedef int (*dbl_cmp)(register union criterion_fp_double, register union criterion_fp_double);
+
+#define IMPL_CMP_ABSEPS(Order)                                                          \
+    int ieee754_ ## Order ## _cmp_abseps(register union criterion_fp_ ## Order val1,    \
+                                         register union criterion_fp_ ## Order val2) {  \
+                                                                                        \
+        fp_type(Order) epsilon = fp_range(Order) * fp_epsilon(Order);                   \
+        fp_type(Order) diff = val1.f - val2.f;                                          \
+        return fp_fabs(Order)(diff) < epsilon ? 0 : (diff > 0 ? 1 : -1);                \
+    }
+
+#define IMPL_CMP_RELEPS(Order)                                                          \
+    int ieee754_ ## Order ## _cmp_releps(register union criterion_fp_ ## Order val1,    \
+                                         register union criterion_fp_ ## Order val2) {  \
+                                                                                        \
+        fp_type(Order) epsilon = fp_range(Order) * fp_epsilon(Order);                   \
+        fp_type(Order) diff = val1.f - val2.f;                                          \
+        fp_type(Order) absdiff = fp_fabs(Order)(diff);                                  \
+                                                                                        \
+        val1.f = fp_fabs(Order)(val1.f);                                                \
+        val2.f = fp_fabs(Order)(val2.f);                                                \
+        fp_type(Order) largest = val1.f > val2.f ? val1.f : val2.f;                     \
+                                                                                        \
+        return absdiff <= largest * epsilon ? 0 : (diff > 0 ? 1 : -1);                  \
+    }
+
+#define IMPL_CMP_ULP(Order)                                                             \
+    int ieee754_ ## Order ## _cmp_ulp(register union criterion_fp_ ## Order val1,       \
+                                      register union criterion_fp_ ## Order val2) {     \
+                                                                                        \
+        size_t max_ulps = fp_range(Order);                                              \
+        const int p1 = fpclassify(val1.f), p2 = fpclassify(val2.f);                     \
+                                                                                        \
+        if (unlikely((val1.i == val2.i || (p1 == FP_ZERO && p2 == FP_ZERO))             \
+                && p1 != FP_NAN && p2 != FP_NAN))                                       \
+            return 0;                                                                   \
+                                                                                        \
+        if (unlikely(p1 == FP_INFINITE || p2 == FP_INFINITE))                           \
+            return val1.f > val2.f;                                                     \
+                                                                                        \
+        const int sign1 = signbit(val1.f), sign2 = signbit(val2.f);                     \
+                                                                                        \
+        if (sign1 != sign2)                                                             \
+            return val1.i == val2.i ? 0 : (val1.f > val2.f ? 1 : -1);                   \
+                                                                                        \
+        int32_t ulpdiff = val1.i - val2.i;                                              \
+        return fp_abs(Order)(ulpdiff) < (int32_t) max_ulps ? 0                          \
+                : (ulpdiff > 0 ? 1 : -1);                                               \
+    }
+
+IMPL_CMP_ABSEPS(single)
+IMPL_CMP_ABSEPS(double)
+IMPL_CMP_RELEPS(single)
+IMPL_CMP_RELEPS(double)
+IMPL_CMP_ULP(single)
+IMPL_CMP_ULP(double)
+
+flt_cmp criterion_flt_strategies[] = {
+    [CR_FP_CMP_RELATIVE_EPSILON]    = ieee754_single_cmp_releps,
+    [CR_FP_CMP_ABSOLUTE_EPSILON]    = ieee754_single_cmp_abseps,
+    [CR_FP_CMP_ULPS]                = ieee754_single_cmp_ulp,
+};
+
+dbl_cmp criterion_dbl_strategies[] = {
+    [CR_FP_CMP_RELATIVE_EPSILON]    = ieee754_double_cmp_releps,
+    [CR_FP_CMP_ABSOLUTE_EPSILON]    = ieee754_double_cmp_abseps,
+    [CR_FP_CMP_ULPS]                = ieee754_double_cmp_ulp,
+};
+
+int cr_float_cmp(struct criterion_fp_any *a, struct criterion_fp_any *b) {
+    assert(a->datasize == b->datasize);
+
+    if (a->datasize == sizeof (float)) {
+        criterion_flt_strategies[fpcmp_opt(strategy)](a->val.sp, b->val.sp);
+    } else if (a->datasize == sizeof (double)) {
+        criterion_dbl_strategies[fpcmp_opt(strategy)](a->val.dp, b->val.dp);
+    }
+    abort();
+}

--- a/src/float/ieee754.c
+++ b/src/float/ieee754.c
@@ -151,9 +151,9 @@ int cr_float_cmp(struct criterion_fp_any *a, struct criterion_fp_any *b) {
     assert(a->datasize == b->datasize);
 
     if (a->datasize == sizeof (float)) {
-        criterion_flt_strategies[fpcmp_opt(strategy)](a->val.sp, b->val.sp);
+        return criterion_flt_strategies[fpcmp_opt(strategy)](a->val.sp, b->val.sp);
     } else if (a->datasize == sizeof (double)) {
-        criterion_dbl_strategies[fpcmp_opt(strategy)](a->val.dp, b->val.dp);
+        return criterion_dbl_strategies[fpcmp_opt(strategy)](a->val.dp, b->val.dp);
     }
     abort();
 }

--- a/src/float/ieee754.c
+++ b/src/float/ieee754.c
@@ -51,8 +51,8 @@ static INLINE int64_t abs64(int64_t x) {
 # define likely(x)   __builtin_expect((x),1)
 # define unlikely(x) __builtin_expect((x),0)
 #else
-# define likely(x)
-# define unlikely(x)
+# define likely(x) x
+# define unlikely(x) x
 #endif
 
 #define fp_abs(Order) fp_abs_ ## Order

--- a/src/float/ieee754.c
+++ b/src/float/ieee754.c
@@ -116,7 +116,7 @@ typedef int (*dbl_cmp)(register union criterion_fp_double, register union criter
             return 0;                                                                   \
                                                                                         \
         if (unlikely(p1 == FP_INFINITE || p2 == FP_INFINITE))                           \
-            return val1.f > val2.f;                                                     \
+            return val1.f < val2.f ? -1 : 1;                                            \
                                                                                         \
         const int sign1 = signbit(val1.f), sign2 = signbit(val2.f);                     \
                                                                                         \

--- a/src/float/ieee754.c
+++ b/src/float/ieee754.c
@@ -136,14 +136,14 @@ IMPL_CMP_ULP(single)
 IMPL_CMP_ULP(double)
 
 flt_cmp criterion_flt_strategies[] = {
-    [CR_FP_CMP_RELATIVE_EPSILON]    = ieee754_single_cmp_releps,
     [CR_FP_CMP_ABSOLUTE_EPSILON]    = ieee754_single_cmp_abseps,
+    [CR_FP_CMP_RELATIVE_EPSILON]    = ieee754_single_cmp_releps,
     [CR_FP_CMP_ULPS]                = ieee754_single_cmp_ulp,
 };
 
 dbl_cmp criterion_dbl_strategies[] = {
-    [CR_FP_CMP_RELATIVE_EPSILON]    = ieee754_double_cmp_releps,
     [CR_FP_CMP_ABSOLUTE_EPSILON]    = ieee754_double_cmp_abseps,
+    [CR_FP_CMP_RELATIVE_EPSILON]    = ieee754_double_cmp_releps,
     [CR_FP_CMP_ULPS]                = ieee754_double_cmp_ulp,
 };
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,6 +9,7 @@ set(TEST_SOURCES
     ordered-set.c
     asprintf.c
     redirect.cc
+    float.cc
 )
 
 add_executable(criterion_unit_tests EXCLUDE_FROM_ALL ${TEST_SOURCES})

--- a/test/float.cc
+++ b/test/float.cc
@@ -1,0 +1,69 @@
+#include "criterion/parameterized.h"
+#include "criterion/options.h"
+#include "criterion/theories.h"
+#include "criterion/float.h"
+#include <cmath>
+#include <cfloat>
+#include <iostream>
+#include <unistd.h>
+
+struct float_compare_params {
+    float arg1;
+    float arg2;
+};
+
+ParameterizedTestParameters(float, eq) {
+    static float_compare_params params[] = {
+        { 0.f,        0.f        },
+        { 1.0f/0.0f,  1.0f/0.0f  },
+        { -1.0f/0.0f, -1.0f/0.0f },
+    };
+
+    return criterion_test_params(params);
+}
+
+ParameterizedTest(float_compare_params *p, float, eq) {
+    criterion_fp_any v1(p->arg1);
+    criterion_fp_any v2(p->arg2);
+
+    cr_assert_eq(cr_float_cmp(&v1, &v2), 0);
+}
+
+# define FLOAT_DP DataPoints(float,                                           \
+    0.f, FLT_EPSILON, FLT_EPSILON * 4.f, FLT_EPSILON / 2.f, 1.0f / 0.0f,      \
+    -0.f, -FLT_EPSILON, -FLT_EPSILON * 4.f, -FLT_EPSILON / 2.f, -1.0f / 0.0f  \
+    )
+
+TheoryDataPoints(float, cmp) {
+    DataPoints(enum criterion_fpcmp_strategy,
+            CR_FP_CMP_RELATIVE_EPSILON,
+            CR_FP_CMP_ABSOLUTE_EPSILON,
+            CR_FP_CMP_ULPS),
+    FLOAT_DP,
+    FLOAT_DP,
+};
+
+Theory((enum criterion_fpcmp_strategy strategy, float arg1, float arg2), float, cmp) {
+    cr_assume(arg1 != arg2);
+
+    criterion_options.floating_point_compare.strategy = strategy;
+    criterion_options.floating_point_compare.flt_range = 0; // never evaluate for equality
+
+    switch (strategy) {
+        case CR_FP_CMP_ABSOLUTE_EPSILON:
+            cr_assume_neq(std::fpclassify(arg1), FP_SUBNORMAL);
+            cr_assume_neq(std::fpclassify(arg2), FP_SUBNORMAL);
+            break;
+        case CR_FP_CMP_RELATIVE_EPSILON:
+        case CR_FP_CMP_ULPS:
+            cr_assume_neq(std::fpclassify(arg1), FP_ZERO);
+            cr_assume_neq(std::fpclassify(arg2), FP_ZERO);
+            break;
+        default: break;
+    }
+
+    criterion_fp_any v1(arg1);
+    criterion_fp_any v2(arg2);
+
+    cr_assert_eq(cr_float_cmp(&v1, &v2), arg1 < arg2 ? -1 : 1);
+}


### PR DESCRIPTION
Two adjascent floats can be considered not equal if the choice of epsilon is unwise. This becomes problematic because the choice of epsilon depends on the order of the two floating point values one is comparing; for instance, between 1e10 and 1e11, an epsilon of 1 is acceptable, while it is not for 1 and 0.9.

Instead, we should be comparing the ULPs of the difference between the two values, effectively using the N next adjascent floats as upper and lower bound for equality.
It should also be noted that FLOAT_MAX and INFINITY are within 1 ULP from each other, so these special cases should also be handled.

Since we are comparing arbitrary floating-point values, there is seemingly no silver bullet, as ULPs are effective for nonzero value comparison, while epsilons are.
Great care should be used while implementing a solution that satisfies any scenario.

An article describing the technique can be found [here](https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/)
