### PR TITLE
Deps: Mark UNUSED parameters in valgrind header

### DIFF
--- a/dependencies/valgrind/include/valgrind/valgrind.h
+++ b/dependencies/valgrind/include/valgrind/valgrind.h
@@ -93,6 +93,7 @@
 
 
 #include <stdarg.h>
+#include <criterion/common.h>
 
 /* Nb: this file might be included in a file compiled with -ansi.  So
    we can't use C++ style "//" comments nor the "asm" keyword (instead
@@ -6220,7 +6221,7 @@ static int
 #if defined(_MSC_VER)
 __inline
 #endif
-VALGRIND_PRINTF(const char *format, ...)
+VALGRIND_PRINTF(UNUSED const char *format, ...)
 {
 #if defined(NVALGRIND)
    return 0;
@@ -6258,7 +6259,7 @@ static int
 #if defined(_MSC_VER)
 __inline
 #endif
-VALGRIND_PRINTF_BACKTRACE(const char *format, ...)
+VALGRIND_PRINTF_BACKTRACE(UNUSED const char *format, ...)
 {
 #if defined(NVALGRIND)
    return 0;


### PR DESCRIPTION
Clang on FreeBSD was complaining:

```csh
[ 26%] Building C object CMakeFiles/criterion.dir/src/core/abort.c.o
[ 30%] Building C object CMakeFiles/criterion.dir/src/core/report.c.o
[ 30%] Building C object CMakeFiles/criterion.dir/src/core/runner.c.o
In file included from /root/projects/Criterion/Criterion/Criterion/src/core/runner.c:29:
/root/projects/Criterion/Criterion/Criterion/dependencies/valgrind/include/valgrind/valgrind.h:6223:29: error: unused
      parameter 'format' [-Werror,-Wunused-parameter]
VALGRIND_PRINTF(const char *format, ...)
                            ^
/root/projects/Criterion/Criterion/Criterion/dependencies/valgrind/include/valgrind/valgrind.h:6261:39: error: unused
      parameter 'format' [-Werror,-Wunused-parameter]
VALGRIND_PRINTF_BACKTRACE(const char *format, ...)
                                      ^
2 errors generated.
```

The other way to fix it was to add a compiler option in CMake:

```cmake
add_compile_options(-Wno-unused-parameter)
```

but this approach disables the check globally.
I am not sure whether there is a way to scope
the compiler option to a subdirectory; especially
in cases where submodule (via `add_subdirectory`)
headers have unsed parameters.