### PR TITLE
Integrate doxygen with sphinx docs

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = ./doc/doxygen
+OUTPUT_DIRECTORY       =
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and
@@ -152,7 +152,7 @@ FULL_PATH_NAMES        = YES
 # will be relative from the directory where doxygen is started.
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
-STRIP_FROM_PATH        =
+STRIP_FROM_PATH        = ../include
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which
@@ -161,7 +161,7 @@ STRIP_FROM_PATH        =
 # specify the list of include paths that are normally passed to the compiler
 # using the -I flag.
 
-STRIP_FROM_INC_PATH    =
+STRIP_FROM_INC_PATH    = ../include
 
 # If the SHORT_NAMES tag is set to YES, doxygen will generate much shorter (but
 # less readable) file names. This can be useful is your file systems doesn't
@@ -177,7 +177,7 @@ SHORT_NAMES            = NO
 # description.)
 # The default value is: NO.
 
-JAVADOC_AUTOBRIEF      = NO
+JAVADOC_AUTOBRIEF      = YES
 
 # If the QT_AUTOBRIEF tag is set to YES then doxygen will interpret the first
 # line (until the first dot) of a Qt-style comment as the brief description. If
@@ -185,7 +185,7 @@ JAVADOC_AUTOBRIEF      = NO
 # requiring an explicit \brief command for a brief description.)
 # The default value is: NO.
 
-QT_AUTOBRIEF           = NO
+QT_AUTOBRIEF           = YES
 
 # The MULTILINE_CPP_IS_BRIEF tag can be set to YES to make doxygen treat a
 # multi-line C++ special comment block (i.e. a block of //! or /// comments) as
@@ -705,7 +705,7 @@ CITE_BIB_FILES         =
 # messages are off.
 # The default value is: NO.
 
-QUIET                  = NO
+QUIET                  = YES
 
 # The WARNINGS tag can be used to turn on/off the warning messages that are
 # generated to standard error (stderr) by doxygen. If WARNINGS is set to YES
@@ -771,7 +771,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ./include/criterion
+INPUT                  = ../include
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -802,7 +802,7 @@ FILE_PATTERNS          =
 # be searched for input files as well.
 # The default value is: NO.
 
-RECURSIVE              =
+RECURSIVE              = YES
 
 # The EXCLUDE tag can be used to specify files and/or directories that should be
 # excluded from the INPUT source files. This way you can easily exclude a
@@ -811,7 +811,7 @@ RECURSIVE              =
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                =
+EXCLUDE                = ../include/criterion/internal/
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded
@@ -1041,7 +1041,7 @@ IGNORE_PREFIX          =
 # If the GENERATE_HTML tag is set to YES, doxygen will generate HTML output
 # The default value is: YES.
 
-GENERATE_HTML          = YES
+GENERATE_HTML          = NO
 
 # The HTML_OUTPUT tag is used to specify where the HTML docs will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of
@@ -1585,7 +1585,7 @@ EXTRA_SEARCH_MAPPINGS  =
 # If the GENERATE_LATEX tag is set to YES, doxygen will generate LaTeX output.
 # The default value is: YES.
 
-GENERATE_LATEX         = YES
+GENERATE_LATEX         = NO
 
 # The LATEX_OUTPUT tag is used to specify where the LaTeX docs will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of
@@ -1865,7 +1865,7 @@ MAN_LINKS              = NO
 # captures the structure of the code including all documentation.
 # The default value is: NO.
 
-GENERATE_XML           = NO
+GENERATE_XML           = YES
 
 # The XML_OUTPUT tag is used to specify where the XML pages will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of
@@ -1873,7 +1873,7 @@ GENERATE_XML           = NO
 # The default directory is: xml.
 # This tag requires that the tag GENERATE_XML is set to YES.
 
-XML_OUTPUT             = xml
+XML_OUTPUT             = doxyxml
 
 # If the XML_PROGRAMLISTING tag is set to YES, doxygen will dump the program
 # listings (including syntax highlighting and cross-referencing information) to

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -107,7 +107,7 @@ BRIEF_MEMBER_DESC      = YES
 # brief descriptions will be completely suppressed.
 # The default value is: YES.
 
-REPEAT_BRIEF           = YES
+REPEAT_BRIEF           = NO
 
 # This tag implements a quasi-intelligent brief description abbreviator that is
 # used to form the text in various listings. Each string in this list, if found

--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -1,7 +1,25 @@
 .breatheparameterlist li p {
-        display: inline;
+    display: inline;
 }
 
 .breatheenumvalues li p {
-        display: inline;
+    display: inline;
+}
+
+.container > dl > dt {
+    display: block;
+    width: 100%;
+    clear: both;
+}
+
+.container > dl > dt:before {
+    content: " ▼ ";
+}
+
+.container > dl > dt.open:before {
+    content: " ▶ ";
+}
+
+.container > dl {
+    margin-bottom: 0 !important; /* Dirty hack */
 }

--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -1,0 +1,7 @@
+.breatheparameterlist li p {
+        display: inline;
+}
+
+.breatheenumvalues li p {
+        display: inline;
+}

--- a/doc/_templates/page.html
+++ b/doc/_templates/page.html
@@ -1,0 +1,3 @@
+{% extends "!page.html" %}
+
+{% set css_files = css_files + ["_static/style.css"] %}

--- a/doc/_templates/page.html
+++ b/doc/_templates/page.html
@@ -1,3 +1,17 @@
 {% extends "!page.html" %}
 
 {% set css_files = css_files + ["_static/style.css"] %}
+
+
+{% block footer %}
+ <script type="text/javascript">
+    $(document).ready(function() {
+        $(".container > dl > *").hide();
+        $(".container > dl > dt").show();
+        $(".container > dl > dt").click(function() {
+            $(this).parent().children().not("dt").toggle(400);
+            $(this).parent().children("dt").toggleClass("open");
+        })
+    });
+</script>
+{% endblock %}

--- a/doc/assert.rst
+++ b/doc/assert.rst
@@ -12,136 +12,35 @@ macros to this list. Hence only ``assert`` macros are represented here.
 All ``assert`` macros may take an optional ``printf`` format string and
 parameters.
 
+Base Assertions
+-----------------
+
+.. doxygengroup:: BaseAsserts
+
 Common Assertions
 -----------------
 
-=========================================================================== =========================================================================== ===========================================
-Macro                                                                        Passes if and only if                                                       Notes
-=========================================================================== =========================================================================== ===========================================
-cr_assert(Condition, [FormatString, [Args...]])                              ``Condition`` is true.
---------------------------------------------------------------------------- --------------------------------------------------------------------------- -------------------------------------------
-cr_assert_not(Condition, [FormatString, [Args...]])                          ``Condition`` is false.
---------------------------------------------------------------------------- --------------------------------------------------------------------------- -------------------------------------------
-cr_assert_null(Value, [FormatString, [Args...]])                             ``Value`` is ``NULL``.
---------------------------------------------------------------------------- --------------------------------------------------------------------------- -------------------------------------------
-cr_assert_not_null(Value, [FormatString, [Args...]])                         ``Value`` is not ``NULL``.
---------------------------------------------------------------------------- --------------------------------------------------------------------------- -------------------------------------------
-cr_assert_eq(Actual, Expected, [FormatString, [Args...]])                    ``Actual`` is equal to ``Expected``.                                        Compatible with C++ operator overloading
---------------------------------------------------------------------------- --------------------------------------------------------------------------- -------------------------------------------
-cr_assert_neq(Actual, Unexpected, [FormatString, [Args...]])                 ``Actual`` is not equal to ``Unexpected``.                                  Compatible with C++ operator overloading
---------------------------------------------------------------------------- --------------------------------------------------------------------------- -------------------------------------------
-cr_assert_lt(Actual, Reference, [FormatString, [Args...]])                   ``Actual`` is less than ``Reference``.                                      Compatible with C++ operator overloading
---------------------------------------------------------------------------- --------------------------------------------------------------------------- -------------------------------------------
-cr_assert_leq(Actual, Reference, [FormatString, [Args...]])                  ``Actual`` is less or equal to ``Reference``.                               Compatible with C++ operator overloading
---------------------------------------------------------------------------- --------------------------------------------------------------------------- -------------------------------------------
-cr_assert_gt(Actual, Reference, [FormatString, [Args...]])                   ``Actual`` is greater than ``Reference``.                                   Compatible with C++ operator overloading
---------------------------------------------------------------------------- --------------------------------------------------------------------------- -------------------------------------------
-cr_assert_geq(Actual, Reference, [FormatString, [Args...]])                  ``Actual`` is greater or equal to ``Reference``.                            Compatible with C++ operator overloading
---------------------------------------------------------------------------- --------------------------------------------------------------------------- -------------------------------------------
-cr_assert_float_eq(Actual, Expected, Epsilon, [FormatString, [Args...]])     ``Actual`` is equal to ``Expected`` with a tolerance of ``Epsilon``.        Use this to test equality between floats
---------------------------------------------------------------------------- --------------------------------------------------------------------------- -------------------------------------------
-cr_assert_float_neq(Actual, Unexpected, Epsilon, [FormatString, [Args...]])  ``Actual`` is not equal to ``Unexpected`` with a tolerance of ``Epsilon``.  Use this to test inequality between floats
-=========================================================================== =========================================================================== ===========================================
+.. doxygengroup:: CommonBinAsserts
+.. doxygengroup:: CommonUnaryAsserts
+.. doxygengroup:: FloatAsserts
 
 String Assertions
 -----------------
 
-Note: these macros are meant to deal with *native* strings, i.e. char arrays.
-Most of them won't work on ``std::string`` in C++, with some exceptions -- for
-``std::string``, you should use regular comparison assersions, as listed above.
-
-================================================================ =================================================================== ===========================================
-Macro                                                            Passes if and only if                                               Notes
-================================================================ =================================================================== ===========================================
-cr_assert_str_empty(Value, [FormatString, [Args...]])            ``Value`` is an empty string.                                       Also works on std::string
----------------------------------------------------------------- ------------------------------------------------------------------- -------------------------------------------
-cr_assert_str_not_empty(Value, [FormatString, [Args...]])        ``Value`` is not an empty string.                                   Also works on std::string
----------------------------------------------------------------- ------------------------------------------------------------------- -------------------------------------------
-cr_assert_str_eq(Actual, Expected, [FormatString, [Args...]])    ``Actual`` is lexicographically equal to ``Expected``.
----------------------------------------------------------------- ------------------------------------------------------------------- -------------------------------------------
-cr_assert_str_neq(Actual, Unexpected, [FormatString, [Args...]]) ``Actual`` is not lexicographically equal to ``Unexpected``.
----------------------------------------------------------------- ------------------------------------------------------------------- -------------------------------------------
-cr_assert_str_lt(Actual, Reference, [FormatString, [Args...]])   ``Actual`` is lexicographically less than ``Reference``.
----------------------------------------------------------------- ------------------------------------------------------------------- -------------------------------------------
-cr_assert_str_leq(Actual, Reference, [FormatString, [Args...]])  ``Actual`` is lexicographically less or equal to ``Reference``.
----------------------------------------------------------------- ------------------------------------------------------------------- -------------------------------------------
-cr_assert_str_gt(Actual, Reference, [FormatString, [Args...]])   ``Actual`` is lexicographically greater than ``Reference``.
----------------------------------------------------------------- ------------------------------------------------------------------- -------------------------------------------
-cr_assert_str_geq(Actual, Reference, [FormatString, [Args...]])  ``Actual`` is lexicographically greater or equal to ``Reference``.
-================================================================ =================================================================== ===========================================
+.. doxygengroup:: StringAsserts
 
 Array Assertions
 -----------------
 
-=============================================================================== =========================================================================== ===========================================
-Macro                                                                            Passes if and only if                                                       Notes
-=============================================================================== =========================================================================== ===========================================
-cr_assert_arr_eq(Actual, Expected, Size, [FormatString, [Args...]])                    ``Actual`` is byte-to-byte equal to ``Expected``.                           This should not be used on struct arrays,
-                                                                                                                                                             consider using ``cr_assert_arr_eq_cmp``
-                                                                                                                                                             instead.
-------------------------------------------------------------------------------- --------------------------------------------------------------------------- -------------------------------------------
-cr_assert_arr_neq(Actual, Unexpected, Size, [FormatString, [Args...]])                 ``Actual`` is not byte-to-byte equal to ``Unexpected``.                     This should not be used on struct arrays,
-                                                                                                                                                             consider using ``cr_assert_arr_neq_cmp``
-                                                                                                                                                             instead.
-------------------------------------------------------------------------------- --------------------------------------------------------------------------- -------------------------------------------
-cr_assert_arr_eq_cmp(Actual, Expected, Size, Cmp, [FormatString, [Args...]])     ``Actual`` is comparatively equal to ``Expected``                           Only available in C++ and GNU C99
-------------------------------------------------------------------------------- --------------------------------------------------------------------------- -------------------------------------------
-cr_assert_arr_neq_cmp(Actual, Unexpected, Size, Cmp, [FormatString, [Args...]])  ``Actual`` is not comparatively equal to ``Expected``                       Only available in C++ and GNU C99
-------------------------------------------------------------------------------- --------------------------------------------------------------------------- -------------------------------------------
-cr_assert_arr_lt_cmp(Actual, Reference, Size, Cmp, [FormatString, [Args...]])    ``Actual`` is comparatively less than ``Reference``                         Only available in C++ and GNU C99
-------------------------------------------------------------------------------- --------------------------------------------------------------------------- -------------------------------------------
-cr_assert_arr_leq_cmp(Actual, Reference, Size, Cmp, [FormatString, [Args...]])   ``Actual`` is comparatively less or equal to ``Reference``                  Only available in C++ and GNU C99
-------------------------------------------------------------------------------- --------------------------------------------------------------------------- -------------------------------------------
-cr_assert_arr_gt_cmp(Actual, Reference, Size, Cmp, [FormatString, [Args...]])    ``Actual`` is comparatively greater than ``Reference``                      Only available in C++ and GNU C99
-------------------------------------------------------------------------------- --------------------------------------------------------------------------- -------------------------------------------
-cr_assert_arr_geq_cmp(Actual, Reference, Size, Cmp, [FormatString, [Args...]])   ``Actual`` is comparatively greater or equal to ``Reference``               Only available in C++ and GNU C99
-=============================================================================== =========================================================================== ===========================================
+.. doxygengroup:: ArrayAsserts
+.. doxygengroup:: SafeArrCmpAsserts
 
 Exception Assertions
 --------------------
 
-The following assertion macros are only defined for C++.
-
-=============================================================================== =========================================================================== ===========================================
-Macro                                                                           Passes if and only if                                                       Notes
-=============================================================================== =========================================================================== ===========================================
-cr_assert_throw(Statement, Exception, [FormatString, [Args...]])                ``Statement`` throws an instance of ``Exception``.
-------------------------------------------------------------------------------- --------------------------------------------------------------------------- -------------------------------------------
-cr_assert_no_throw(Statement, Exception, [FormatString, [Args...]])             ``Statement`` does not throws an instance of ``Exception``.
-------------------------------------------------------------------------------- --------------------------------------------------------------------------- -------------------------------------------
-cr_assert_any_throw(Statement, [FormatString, [Args...]])                       ``Statement`` throws any kind of exception.
-------------------------------------------------------------------------------- --------------------------------------------------------------------------- -------------------------------------------
-cr_assert_none_throw(Statement, [FormatString, [Args...]])                      ``Statement`` does not throw any exception.
-=============================================================================== =========================================================================== ===========================================
+.. doxygengroup:: ExceptionAsserts
 
 File Assertions
 ---------------
 
-=================================================================================== ============================================================================ ===========================================
-Macro                                                                               Passes if and only if                                                        Notes
-=================================================================================== ============================================================================ ===========================================
-cr_assert_file_contents_eq_str(File, ExpectedContents, [FormatString, [Args...]])   The contents of ``File`` are equal to the string ``ExpectedContents``.
------------------------------------------------------------------------------------ ---------------------------------------------------------------------------- -------------------------------------------
-cr_assert_file_contents_neq_str(File, ExpectedContents, [FormatString, [Args...]])  The contents of ``File`` are not equal to the string ``ExpectedContents``.
------------------------------------------------------------------------------------ ---------------------------------------------------------------------------- -------------------------------------------
-cr_assert_stdout_eq_str(ExpectedContents, [FormatString, [Args...]])                The contents of ``stdout`` are equal to the string ``ExpectedContents``.
------------------------------------------------------------------------------------ ---------------------------------------------------------------------------- -------------------------------------------
-cr_assert_stdout_neq_str(ExpectedContents, [FormatString, [Args...]])               The contents of ``stdout`` are not equal to the string ``ExpectedContents``.
------------------------------------------------------------------------------------ ---------------------------------------------------------------------------- -------------------------------------------
-cr_assert_stderr_eq_str(ExpectedContents, [FormatString, [Args...]])                The contents of ``stderr`` are equal to the string ``ExpectedContents``.
------------------------------------------------------------------------------------ ---------------------------------------------------------------------------- -------------------------------------------
-cr_assert_stderr_neq_str(ExpectedContents, [FormatString, [Args...]])               The contents of ``stderr`` are not equal to the string ``ExpectedContents``.
------------------------------------------------------------------------------------ ---------------------------------------------------------------------------- -------------------------------------------
-cr_assert_file_contents_eq(File, RefFile, [FormatString, [Args...]])                The contents of ``File`` are equal to the contents of ``RefFile``.
------------------------------------------------------------------------------------ ---------------------------------------------------------------------------- -------------------------------------------
-cr_assert_file_contents_neq(File, RefFile, [FormatString, [Args...]])               The contents of ``File`` are not equal to the contents of ``RefFile``.
------------------------------------------------------------------------------------ ---------------------------------------------------------------------------- -------------------------------------------
-cr_assert_stdout_eq(RefFile, [FormatString, [Args...]])                             The contents of ``stdout`` are equal to the contents of ``RefFile``.
------------------------------------------------------------------------------------ ---------------------------------------------------------------------------- -------------------------------------------
-cr_assert_stdout_neq(RefFile, [FormatString, [Args...]])                            The contents of ``stdout`` are not equal to the contents of ``RefFile``.
------------------------------------------------------------------------------------ ---------------------------------------------------------------------------- -------------------------------------------
-cr_assert_stderr_eq(RefFile, [FormatString, [Args...]])                             The contents of ``stderr`` are equal to the contents of ``RefFile``.
------------------------------------------------------------------------------------ ---------------------------------------------------------------------------- -------------------------------------------
-cr_assert_stderr_neq(RefFile, [FormatString, [Args...]])                            The contents of ``stderr`` are not equal to the contents of ``RefFile``.
-=================================================================================== ============================================================================ ===========================================
-
+.. doxygengroup:: FileAsserts

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -13,10 +13,25 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "_ext"))
 # If your documentation needs a minimal Sphinx version, state it here.
 #needs_sphinx = '1.0'
 
+# hack for readthedocs to cause it to run doxygen first
+# https://github.com/rtfd/readthedocs.org/issues/388
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+if on_rtd:
+  from subprocess import call
+  call('doxygen')
+
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = []
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.todo',
+    'sphinx.ext.viewcode',
+    'breathe',
+]
+
+breathe_projects = { "criterion-doxygen": "doxyxml/" }
+breathe_default_project = "criterion-doxygen"
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/doc/parameterized.rst
+++ b/doc/parameterized.rst
@@ -14,6 +14,8 @@ Adding parameterized tests
 Adding parameterized tests is done by defining the parameterized test function,
 and the parameter generator function:
 
+.. doxygengroup:: ParameterizedBase
+
 .. code-block:: c
 
     #include <criterion/parameterized.h>

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,1 @@
+breathe

--- a/doc/starter.rst
+++ b/doc/starter.rst
@@ -6,6 +6,10 @@ Adding tests
 
 Adding tests is done using the ``Test`` macro:
 
+.. doxygendefine:: Test
+
+Example:
+
 .. code-block:: c
 
     #include <criterion/criterion.h>
@@ -147,27 +151,18 @@ Configuration reference
 Here is an exhaustive list of all possible configuration parameters you can
 pass:
 
-============= =============== ==============================================================
-Parameter     Type            Description
-============= =============== ==============================================================
-.description  const char *    Adds a description. Cannot be ``NULL``.
-------------- --------------- --------------------------------------------------------------
-.init         void (*)(void)  Adds a setup function the be executed before the test.
-------------- --------------- --------------------------------------------------------------
-.fini         void (*)(void)  Adds a teardown function the be executed after the test.
-------------- --------------- --------------------------------------------------------------
-.disabled     bool            Disables the test.
-------------- --------------- --------------------------------------------------------------
-.signal       int             Expect the test to raise the specified signal.
-------------- --------------- --------------------------------------------------------------
-.exit_code    int             Expect the test to exit with the specified status.
-============= =============== ==============================================================
+.. doxygenstruct:: criterion_test_extra_data
+    :members:
 
 Setting up suite-wise configuration
 -----------------------------------
 
 Tests under the same suite can have a suite-wise configuration -- this is done
 using the ``TestSuite`` macro:
+
+.. doxygendefine:: TestSuite
+
+Example:
 
 .. code-block:: c
 

--- a/doc/theories.rst
+++ b/doc/theories.rst
@@ -55,53 +55,7 @@ making the test fail.
 
 On top of those, more ``assume`` macro functions are available for common operations:
 
-======================================================= ====================================================
-Macro                                                   Description
-======================================================= ====================================================
-``cr_assume_not(Condition)``                            Assumes Condition is false.
-------------------------------------------------------- ----------------------------------------------------
-``cr_assume_null(Ptr)``                                 Assumes Ptr is NULL.
-------------------------------------------------------- ----------------------------------------------------
-``cr_assume_not_null(Ptr)``                             Assumes Ptr is not NULL.
-------------------------------------------------------- ----------------------------------------------------
-``cr_assume_eq(Actual, Expected)``                      Assumes Actual == Expected.
-------------------------------------------------------- ----------------------------------------------------
-``cr_assume_neq(Actual, Unexpected)``                   Assumes Actual != Expected.
-------------------------------------------------------- ----------------------------------------------------
-``cr_assume_lt(Actual, Expected)``                      Assumes Actual < Expected.
-------------------------------------------------------- ----------------------------------------------------
-``cr_assume_leq(Actual, Expected)``                     Assumes Actual <= Expected.
-------------------------------------------------------- ----------------------------------------------------
-``cr_assume_gt(Actual, Expected)``                      Assumes Actual > Expected.
-------------------------------------------------------- ----------------------------------------------------
-``cr_assume_geq(Actual, Expected)``                     Assumes Actual >= Expected.
-------------------------------------------------------- ----------------------------------------------------
-``cr_assume_float_eq(Actual, Expected, Epsilon)``       Assumes Actual == Expected with an error of Epsilon.
-------------------------------------------------------- ----------------------------------------------------
-``cr_assume_float_neq(Actual, Unexpected, Epsilon)``    Assumes Actual != Expected with an error of Epsilon.
-------------------------------------------------------- ----------------------------------------------------
-``cr_assume_str_eq(Actual, Expected)``                  Assumes Actual and Expected are the same string.
-------------------------------------------------------- ----------------------------------------------------
-``cr_assume_str_neq(Actual, Unexpected)``               Assumes Actual and Expected are not the same string.
-------------------------------------------------------- ----------------------------------------------------
-``cr_assume_str_lt(Actual, Expected)``                  Assumes Actual is less than Expected
-                                                        lexicographically.
-------------------------------------------------------- ----------------------------------------------------
-``cr_assume_str_leq(Actual, Expected)``                 Assumes Actual is less or equal to Expected
-                                                        lexicographically.
-------------------------------------------------------- ----------------------------------------------------
-``cr_assume_str_gt(Actual, Expected)``                  Assumes Actual is greater than Expected
-                                                        lexicographically.
-------------------------------------------------------- ----------------------------------------------------
-``cr_assume_str_geq(Actual, Expected)``                 Assumes Actual is greater or equal to Expected
-                                                        lexicographically.
-------------------------------------------------------- ----------------------------------------------------
-``cr_assume_arr_eq(Actual, Expected, Size)``            Assumes all elements of Actual (from 0 to Size - 1)
-                                                        are equals to those of Expected.
-------------------------------------------------------- ----------------------------------------------------
-``cr_assume_arr_neq(Actual, Unexpected, Size)``         Assumes one or more elements of Actual (from 0 to
-                                                        Size - 1) differs from their counterpart in Expected.
-======================================================= ====================================================
+.. doxygengroup:: TheoryInvariants
 
 Configuring theories
 --------------------

--- a/doc/theories.rst
+++ b/doc/theories.rst
@@ -10,6 +10,8 @@ parameters known as "data points".
 Adding theories
 ---------------
 
+.. doxygengroup:: TheoryBase
+
 Adding theories is done by defining data points and a theory function:
 
 .. code-block:: c

--- a/include/criterion/assert.h
+++ b/include/criterion/assert.h
@@ -894,6 +894,10 @@
  * Otherwise the test is marked as failure and the execution of the function
  * is aborted.
  *
+ * The macro takes a `int (*comparator)(typeof(Actual) a, typeof(Expected) b)`
+ * function pointer, that returns -1, 0, or 1 when `a` is respectively less,
+ * equal to, or greater than `b`.
+ *
  * The optional string is printed on failure.
  *
  * @note This macro is only available on C++ and GNU C compilers.
@@ -901,8 +905,7 @@
  * @param[in] Actual Array to test
  * @param[in] Expected Expected array
  * @param[in] Size Number of bytes to check
- * @param[in] Cmp Function pointer to a function int fn(<type of Actual>,
- * <type of Expected>) to do the comparison
+ * @param[in] Cmp The comparator to use
  * @param[in] FormatString (optional) printf-like format string
  * @param[in] ... (optional) format string parameters
  *
@@ -915,6 +918,10 @@
  * Passes if Actual is comparatively equal to Expected.
  * Otherwise the test is marked as failure but the execution will continue.
  *
+ * The macro takes a `int (*comparator)(typeof(Actual) a, typeof(Expected) b)`
+ * function pointer, that returns -1, 0, or 1 when `a` is respectively less,
+ * equal to, or greater than `b`.
+ *
  * The optional string is printed on failure.
  *
  * @note This macro is only available on C++ and GNU C compilers.
@@ -922,8 +929,7 @@
  * @param[in] Actual Array to test
  * @param[in] Expected Expected array
  * @param[in] Size Number of bytes to check
- * @param[in] Cmp Function pointer to a function int fn(<type of Actual>,
- * <type of Expected>) to do the comparison
+ * @param[in] Cmp The comparator to use
  * @param[in] FormatString (optional) printf-like format string
  * @param[in] ... (optional) format string parameters
  *
@@ -938,6 +944,10 @@
  * Otherwise the test is marked as failure and the execution of the function
  * is aborted.
  *
+ * The macro takes a `int (*comparator)(typeof(Actual) a, typeof(Expected) b)`
+ * function pointer, that returns -1, 0, or 1 when `a` is respectively less,
+ * equal to, or greater than `b`.
+ *
  * The optional string is printed on failure.
  *
  * @note This macro is only available on C++ and GNU C compilers.
@@ -945,8 +955,7 @@
  * @param[in] Actual Array to test
  * @param[in] Unexpected Unexpected array
  * @param[in] Size Number of bytes to check
- * @param[in] Cmp Function pointer to a function int fn(<type of Actual>,
- * <type of Unexpected>) to do the comparison
+ * @param[in] Cmp The comparator to use
  * @param[in] FormatString (optional) printf-like format string
  * @param[in] ... (optional) format string parameters
  *
@@ -960,6 +969,10 @@
  * Passes if Actual is not comparatively equal to Unexpected.
  * Otherwise the test is marked as failure but the execution will continue.
  *
+ * The macro takes a `int (*comparator)(typeof(Actual) a, typeof(Expected) b)`
+ * function pointer, that returns -1, 0, or 1 when `a` is respectively less,
+ * equal to, or greater than `b`.
+ *
  * The optional string is printed on failure.
  *
  * @note This macro is only available on C++ and GNU C compilers.
@@ -967,8 +980,7 @@
  * @param[in] Actual Array to test
  * @param[in] Unexpected Unexpected array
  * @param[in] Size Number of bytes to check
- * @param[in] Cmp Function pointer to a function int fn(<type of Actual>,
- * <type of Unexpected>) to do the comparison
+ * @param[in] Cmp The comparator to use
  * @param[in] FormatString (optional) printf-like format string
  * @param[in] ... (optional) format string parameters
  *
@@ -982,6 +994,10 @@
  * Otherwise the test is marked as failure and the execution of the function
  * is aborted.
  *
+ * The macro takes a `int (*comparator)(typeof(Actual) a, typeof(Expected) b)`
+ * function pointer, that returns -1, 0, or 1 when `a` is respectively less,
+ * equal to, or greater than `b`.
+ *
  * The optional string is printed on failure.
  *
  * @note This macro is only available on C++ and GNU C compilers.
@@ -989,8 +1005,7 @@
  * @param[in] Actual Array to test
  * @param[in] Reference Reference array
  * @param[in] Size Number of bytes to check
- * @param[in] Cmp Function pointer to a function int fn(<type of Actual>,
- * <type of Reference>) to do the comparison
+ * @param[in] Cmp The comparator to use
  * @param[in] FormatString (optional) printf-like format string
  * @param[in] ... (optional) format string parameters
  *
@@ -1003,6 +1018,10 @@
  * Passes if Actual is  comparatively less than Reference.
  * Otherwise the test is marked as failure but the execution will continue.
  *
+ * The macro takes a `int (*comparator)(typeof(Actual) a, typeof(Expected) b)`
+ * function pointer, that returns -1, 0, or 1 when `a` is respectively less,
+ * equal to, or greater than `b`.
+ *
  * The optional string is printed on failure.
  *
  * @note This macro is only available on C++ and GNU C compilers.
@@ -1010,8 +1029,7 @@
  * @param[in] Actual Array to test
  * @param[in] Reference Reference array
  * @param[in] Size Number of bytes to check
- * @param[in] Cmp Function pointer to a function int fn(<type of Actual>,
- * <type of Reference>) to do the comparison
+ * @param[in] Cmp The comparator to use
  * @param[in] FormatString (optional) printf-like format string
  * @param[in] ... (optional) format string parameters
  *
@@ -1026,6 +1044,10 @@
  * Otherwise the test is marked as failure and the execution of the function
  * is aborted.
  *
+ * The macro takes a `int (*comparator)(typeof(Actual) a, typeof(Expected) b)`
+ * function pointer, that returns -1, 0, or 1 when `a` is respectively less,
+ * equal to, or greater than `b`.
+ *
  * The optional string is printed on failure.
  *
  * @note This macro is only available on C++ and GNU C compilers.
@@ -1033,8 +1055,7 @@
  * @param[in] Actual Array to test
  * @param[in] Reference Reference array
  * @param[in] Size Number of bytes to check
- * @param[in] Cmp Function pointer to a function int fn(<type of Actual>,
- * <type of Reference>) to do the comparison
+ * @param[in] Cmp The comparator to use
  * @param[in] FormatString (optional) printf-like format string
  * @param[in] ... (optional) format string parameters
  *
@@ -1048,6 +1069,10 @@
  * Passes if Actual is  comparatively less or equal to Reference.
  * Otherwise the test is marked as failure but the execution will continue.
  *
+ * The macro takes a `int (*comparator)(typeof(Actual) a, typeof(Expected) b)`
+ * function pointer, that returns -1, 0, or 1 when `a` is respectively less,
+ * equal to, or greater than `b`.
+ *
  * The optional string is printed on failure.
  *
  * @note This macro is only available on C++ and GNU C compilers.
@@ -1055,8 +1080,7 @@
  * @param[in] Actual Array to test
  * @param[in] Reference Reference array
  * @param[in] Size Number of bytes to check
- * @param[in] Cmp Function pointer to a function int fn(<type of Actual>,
- * <type of Reference>) to do the comparison
+ * @param[in] Cmp The comparator to use
  * @param[in] FormatString (optional) printf-like format string
  * @param[in] ... (optional) format string parameters
  *
@@ -1070,6 +1094,10 @@
  * Otherwise the test is marked as failure and the execution of the function
  * is aborted.
  *
+ * The macro takes a `int (*comparator)(typeof(Actual) a, typeof(Expected) b)`
+ * function pointer, that returns -1, 0, or 1 when `a` is respectively less,
+ * equal to, or greater than `b`.
+ *
  * The optional string is printed on failure.
  *
  * @note This macro is only available on C++ and GNU C compilers.
@@ -1077,8 +1105,7 @@
  * @param[in] Actual Array to test
  * @param[in] Reference Reference array
  * @param[in] Size Number of bytes to check
- * @param[in] Cmp Function pointer to a function int fn(<type of Actual>,
- * <type of Reference>) to do the comparison
+ * @param[in] Cmp The comparator to use
  * @param[in] FormatString (optional) printf-like format string
  * @param[in] ... (optional) format string parameters
  *
@@ -1091,6 +1118,10 @@
  * Passes if Actual is  comparatively greater than Reference.
  * Otherwise the test is marked as failure but the execution will continue.
  *
+ * The macro takes a `int (*comparator)(typeof(Actual) a, typeof(Expected) b)`
+ * function pointer, that returns -1, 0, or 1 when `a` is respectively less,
+ * equal to, or greater than `b`.
+ *
  * The optional string is printed on failure.
  *
  * @note This macro is only available on C++ and GNU C compilers.
@@ -1098,8 +1129,7 @@
  * @param[in] Actual Array to test
  * @param[in] Reference Reference array
  * @param[in] Size Number of bytes to check
- * @param[in] Cmp Function pointer to a function int fn(<type of Actual>,
- * <type of Reference>) to do the comparison
+ * @param[in] Cmp The comparator to use
  * @param[in] FormatString (optional) printf-like format string
  * @param[in] ... (optional) format string parameters
  *
@@ -1114,6 +1144,10 @@
  * Otherwise the test is marked as failure and the execution of the function
  * is aborted.
  *
+ * The macro takes a `int (*comparator)(typeof(Actual) a, typeof(Expected) b)`
+ * function pointer, that returns -1, 0, or 1 when `a` is respectively less,
+ * equal to, or greater than `b`.
+ *
  * The optional string is printed on failure.
  *
  * @note This macro is only available on C++ and GNU C compilers.
@@ -1121,8 +1155,7 @@
  * @param[in] Actual Array to test
  * @param[in] Reference Reference array
  * @param[in] Size Number of bytes to check
- * @param[in] Cmp Function pointer to a function int fn(<type of Actual>,
- * <type of Reference>) to do the comparison
+ * @param[in] Cmp The comparator to use
  * @param[in] FormatString (optional) printf-like format string
  * @param[in] ... (optional) format string parameters
  *
@@ -1136,6 +1169,10 @@
  * Passes if Actual is  comparatively greater or equal to Reference.
  * Otherwise the test is marked as failure but the execution will continue.
  *
+ * The macro takes a `int (*comparator)(typeof(Actual) a, typeof(Expected) b)`
+ * function pointer, that returns -1, 0, or 1 when `a` is respectively less,
+ * equal to, or greater than `b`.
+ *
  * The optional string is printed on failure.
  *
  * @note This macro is only available on C++ and GNU C compilers.
@@ -1143,8 +1180,7 @@
  * @param[in] Actual Array to test
  * @param[in] Reference Reference array
  * @param[in] Size Number of bytes to check
- * @param[in] Cmp Function pointer to a function int fn(<type of Actual>,
- * <type of Reference>) to do the comparison
+ * @param[in] Cmp The comparator to use
  * @param[in] FormatString (optional) printf-like format string
  * @param[in] ... (optional) format string parameters
  *

--- a/include/criterion/assert.h
+++ b/include/criterion/assert.h
@@ -33,8 +33,6 @@
 #  include <algorithm>
 # endif
 
-# include "internal/assert.h"
-
 /**
  * @defgroup BaseAsserts Base assertions
  * @{
@@ -43,39 +41,31 @@
 /**
  * Fails always.
  *
- * Call: \c cr_assert_fail([FormatString, [Args...]]).
- *
  * The test is marked as failure and the execution of the function is aborted.
  *
  * The optional string is printed on failure.
  *
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_assert_fail(...) CR_EXPAND(cr_fail(CR_FAIL_ABORT_,     __VA_ARGS__))
+# define cr_assert_fail(FormatString, ...) <internal>
 
 /**
  * Fails always.
- *
- * Call: \c cr_expect_fail([FormatString, [Args...]]).
  *
  * The test is marked as failure but the execution will continue.
  *
  * The optional string is printed on failure.
  *
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_expect_fail(...) CR_EXPAND(cr_fail(CR_FAIL_CONTINUES_, __VA_ARGS__))
+# define cr_expect_fail(FormatString, ...) <internal>
 
 /**
  * Passes if Condition is true
- *
- * Call: \c cr_assert(Condition, [FormatString, [Args...]]).
  *
  * Evaluates the condition and passes if it is true.
  * Otherwise the test is marked as failure and the execution of the function
@@ -84,17 +74,14 @@
  * The optional string is printed on failure.
  *
  * @param[in] Condition Condition to test
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_assert(...) CR_EXPAND(cr_assert_(__VA_ARGS__))
+# define cr_assert(Condition, FormatString, ...) <internal>
 
 /**
  * Passes if Condition is true
- *
- * Call: \c cr_expect(Condition, [FormatString, [Args...]]).
  *
  * Evaluates the condition and passes if it is true.
  * Otherwise the test is marked as failure but the execution will continue.
@@ -102,17 +89,14 @@
  * The optional string is printed on failure.
  *
  * @param[in] Condition Condition to test
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_expect(...) CR_EXPAND(cr_expect_(__VA_ARGS__))
+# define cr_expect(Condition, FormatString, ...) <internal>
 
 /**
  * Passes if Condition is false
- *
- * Call: \c cr_assert_not(Condition, [FormatString, [Args...]])
  *
  * Evaluates the condition and passes if it is false.
  * Otherwise the test is marked as failure and the execution of the function
@@ -121,17 +105,14 @@
  * The optional string is printed on failure.
  *
  * @param[in] Condition Condition to test
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_assert_not(...) CR_EXPAND(cr_assert_not_(__VA_ARGS__))
+# define cr_assert_not(Condition, FormatString, ...) <internal>
 
 /**
  * Passes if Condition is false
- *
- * Call: \c cr_expect_not(Condition, [FormatString, [Args...]])
  *
  * Evaluates the condition and passes if it is false.
  * Otherwise the test is marked as failure but the execution will continue.
@@ -139,12 +120,11 @@
  * The optional string is printed on failure.
  *
  * @param[in] Condition Condition to test
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_expect_not(...) CR_EXPAND(cr_expect_not_(__VA_ARGS__))
+# define cr_expect_not(Condition, FormatString, ...) <internal>
 
 /**@}*/
 
@@ -156,8 +136,6 @@
 /**
  * Passes if Actual is equal to Expected
  *
- * Call: \c cr_assert_eq(Actual, Expected, [FormatString, [Args...]])
- *
  * Passes if Actual is equal to Expected.
  * Otherwise the test is marked as failure and the execution of the function
  * is aborted.
@@ -168,17 +146,14 @@
  *
  * @param[in] Actual Value to test
  * @param[in] Expected Expected value
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_assert_eq(...) CR_EXPAND(cr_assert_op_va_(CR_FAIL_ABORT_,      ==, __VA_ARGS__))
+# define cr_assert_eq(Actual, Expected, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is equal to Expected
- *
- * Call: \c cr_expect_eq(Actual, Expected, [FormatString, [Args...]])
  *
  * Passes if Actual is equal to Expected.
  * Otherwise the test is marked as failure but the execution will continue.
@@ -189,17 +164,14 @@
  *
  * @param[in] Actual Value to test
  * @param[in] Expected Expected value
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_expect_eq(...) CR_EXPAND(cr_assert_op_va_(CR_FAIL_CONTINUES_,  ==, __VA_ARGS__))
+# define cr_expect_eq(Actual, Expected, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is not equal to Unexpected
- *
- * Call: \c cr_assert_neq(Actual, Unexpected, [FormatString, [Args...]])
  *
  * Passes if Actual is not equal to Unexpected
  * Otherwise the test is marked as failure and the execution of the function
@@ -211,17 +183,14 @@
  *
  * @param[in] Actual Value to test
  * @param[in] Unexpected Unexpected Value
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_assert_neq(...) CR_EXPAND(cr_assert_op_va_(CR_FAIL_ABORT_,     !=, __VA_ARGS__))
+# define cr_assert_neq(Actual, Unexpected, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is not equal to Unexpected
- *
- * Call: \c cr_expect_neq(Actual, Unexpected, [FormatString, [Args...]])
  *
  * Passes if Actual is not equal to Unexpected.
  * Otherwise the test is marked as failure but the execution will continue.
@@ -232,17 +201,14 @@
  *
  * @param[in] Actual Value to test
  * @param[in] Unexpected Unexpected Value
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_expect_neq(...) CR_EXPAND(cr_assert_op_va_(CR_FAIL_CONTINUES_, !=, __VA_ARGS__))
+# define cr_expect_neq(Actual, Unexpected, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is less than Reference
- *
- * Call: \c cr_assert_lt(Actual, Reference, [FormatString, [Args...]])
  *
  * Passes if Actual is less than Reference.
  * Otherwise the test is marked as failure and the execution of the function
@@ -254,17 +220,14 @@
  *
  * @param[in] Actual Value to test
  * @param[in] Reference Reference value
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_assert_lt(...) CR_EXPAND(cr_assert_op_va_(CR_FAIL_ABORT_,      <, __VA_ARGS__))
+# define cr_assert_lt(Actual, Reference, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is less than Reference
- *
- * Call: \c cr_expect_lt(Actual, Reference, [FormatString, [Args...]])
  *
  * Passes if Actual is less than Reference.
  * Otherwise the test is marked as failure but the execution will continue.
@@ -275,18 +238,14 @@
  *
  * @param[in] Actual Value to test
  * @param[in] Reference Reference value
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_expect_lt(...) CR_EXPAND(cr_assert_op_va_(CR_FAIL_CONTINUES_,  <, __VA_ARGS__))
-
+# define cr_expect_lt(Actual, Reference, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is less or equal to Reference
- *
- * Call: \c cr_assert_leq(Actual, Reference, [FormatString, [Args...]])
  *
  * Passes if Actual is less or equal to Reference.
  * Otherwise the test is marked as failure and the execution of the function
@@ -298,16 +257,14 @@
  *
  * @param[in] Actual Value to test
  * @param[in] Reference Reference value
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-# define cr_assert_leq(...) CR_EXPAND(cr_assert_op_va_(CR_FAIL_ABORT_,     <=, __VA_ARGS__))
+# define cr_assert_leq(Actual, Reference, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is less or equal to Reference
- *
- * Call: \c cr_expect_leq(Actual, Reference, [FormatString, [Args...]])
  *
  * Passes if Actual is less or equal to Reference.
  * Otherwise the test is marked as failure but the execution will continue.
@@ -318,18 +275,14 @@
  *
  * @param[in] Actual Value to test
  * @param[in] Reference Reference value
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_expect_leq(...) CR_EXPAND(cr_assert_op_va_(CR_FAIL_CONTINUES_, <=, __VA_ARGS__))
-
+# define cr_expect_leq(Actual, Reference, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is greater than Reference
- *
- * Call: \c cr_assert_gt(Actual, Reference, [FormatString, [Args...]])
  *
  * Passes if Actual is greater than Reference.
  * Otherwise the test is marked as failure and the execution of the function
@@ -341,16 +294,14 @@
  *
  * @param[in] Actual Value to test
  * @param[in] Reference Reference value
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-# define cr_assert_gt(...) CR_EXPAND(cr_assert_op_va_(CR_FAIL_ABORT_,      >, __VA_ARGS__))
+# define cr_assert_gt(Actual, Reference, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is greater than Reference
- *
- * Call: \c cr_expect_gt(Actual, Reference, [FormatString, [Args...]])
  *
  * Passes if Actual is greater than Reference.
  * Otherwise the test is marked as failure but the execution will continue.
@@ -361,17 +312,14 @@
  *
  * @param[in] Actual Value to test
  * @param[in] Reference Reference value
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-# define cr_expect_gt(...) CR_EXPAND(cr_assert_op_va_(CR_FAIL_CONTINUES_,  >, __VA_ARGS__))
-
+# define cr_expect_gt(Actual, Reference, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is greater or equal to Reference
- *
- * Call: \c cr_assert_geq(Actual, Reference, [FormatString, [Args...]])
  *
  * Passes if Actual is greater or equal to Reference.
  * Otherwise the test is marked as failure and the execution of the function
@@ -383,16 +331,14 @@
  *
  * @param[in] Actual Value to test
  * @param[in] Reference Reference value
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-# define cr_assert_geq(...) CR_EXPAND(cr_assert_op_va_(CR_FAIL_ABORT_,     >=, __VA_ARGS__))
+# define cr_assert_geq(Actual, Reference, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is greater or equal to Reference
- *
- * Call: \c cr_expect_geq(Actual, Reference, [FormatString, [Args...]])
  *
  * Passes if Actual is greater or equal to Reference.
  * Otherwise the test is marked as failure but the execution will continue.
@@ -403,11 +349,11 @@
  *
  * @param[in] Actual Value to test
  * @param[in] Reference Reference value
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-# define cr_expect_geq(...) CR_EXPAND(cr_assert_op_va_(CR_FAIL_CONTINUES_, >=, __VA_ARGS__))
+# define cr_expect_geq(Actual, Reference, FormatString, ...) <internal>
 
 /**@}*/
 
@@ -419,8 +365,6 @@
 /**
  * Passes if Value is NULL
  *
- * Call: \c cr_expect_null(Value, [FormatString, [Args...]])
- *
  * Passes if Value is NULL.
  * Otherwise the test is marked as failure and the execution of the function
  * is aborted.
@@ -428,34 +372,29 @@
  * The optional string is printed on failure.
  *
  * @param[in] Actual Value to test
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-# define cr_assert_null(...) CR_EXPAND(cr_assert_null_op_va_(CR_FAIL_ABORT_,     ==, CRITERION_ASSERT_MSG_IS_NOT_NULL, __VA_ARGS__))
+# define cr_assert_null(Value, FormatString, ...) <internal>
 
 /**
  * Passes if Value is NULL
  *
- * Call: \c cr_expect_null(Value, [FormatString, [Args...]])
- *
  * Passes if Value is NULL.
  * Otherwise the test is marked as failure but the execution will continue.
  *
  * The optional string is printed on failure.
  *
  * @param[in] Actual Value to test
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_expect_null(...) CR_EXPAND(cr_assert_null_op_va_(CR_FAIL_CONTINUES_, ==, CRITERION_ASSERT_MSG_IS_NOT_NULL, __VA_ARGS__))
+# define cr_expect_null(Value, FormatString, ...) <internal>
 
 /**
  * Passes if Value is not NULL
- *
- * Call: \c cr_assert_not_null(Value, [FormatString, [Args...]])
  *
  * Passes if Value is not NULL.
  * Otherwise the test is marked as failure and the execution of the function
@@ -463,30 +402,27 @@
  *
  * The optional string is printed on failure.
  *
- * @param[in] Actual Value to test
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] Value Value to test
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-# define cr_assert_not_null(...) CR_EXPAND(cr_assert_null_op_va_(CR_FAIL_ABORT_,     !=, CRITERION_ASSERT_MSG_IS_NULL, __VA_ARGS__))
+# define cr_assert_not_null(Value, FormatString, ...) <internal>
 
 /**
  * Passes if Value is not NULL
- *
- * Call: \c cr_expect_not_null(Value, [FormatString, [Args...]])
  *
  * Passes if Value is not NULL.
  * Otherwise the test is marked as failure but the execution will continue.
  *
  * The optional string is printed on failure.
  *
- * @param[in] Actual Value to test
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] Value Value to test
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_expect_not_null(...) CR_EXPAND(cr_assert_null_op_va_(CR_FAIL_CONTINUES_, !=, CRITERION_ASSERT_MSG_IS_NULL, __VA_ARGS__))
+# define cr_expect_not_null(Value, FormatString, ...) <internal>
 
 /**@}*/
 
@@ -498,9 +434,6 @@
 /**
  * Passes if Actual is equal to Expected with a tolerance of Epsilon
  *
- * Call: \c cr_assert_float_eq(Actual, Expected, Epsilon, [FormatString,
- * [Args...]])
- *
  * Passes if Actual is equal to Expected with a tolerance of Epsilon.
  * Otherwise the test is marked as failure and the execution of the function
  * is aborted.
@@ -512,18 +445,15 @@
  * @param[in] Actual Value to test
  * @param[in] Expected Expected value
  * @param[in] Epsilon Tolerance between Actual and Expected
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-# define cr_assert_float_eq(...) CR_EXPAND(cr_assert_float_op_va_(CR_FAIL_ABORT_,     cr_assert_float_eq_op_, __VA_ARGS__))
+# define cr_assert_float_eq(Actual, Expected, Epsilon, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is equal to Expected with a tolerance of Epsilon
  *
- * Call: \c cr_expect_float_eq(Actual, Expected, Epsilon, [FormatString,
- * [Args...]])
- *
  * Passes if Actual is equal to Expected with a tolerance of Epsilon.
  * Otherwise the test is marked as failure but the execution will continue.
  *
@@ -534,18 +464,14 @@
  * @param[in] Actual Value to test
  * @param[in] Expected Expected value
  * @param[in] Epsilon Tolerance between Actual and Expected
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_expect_float_eq(...) CR_EXPAND(cr_assert_float_op_va_(CR_FAIL_CONTINUES_, cr_assert_float_eq_op_, __VA_ARGS__))
+# define cr_expect_float_eq(Actual, Expected, Epsilon, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is not equal to Unexpected with a tolerance of Epsilon
- *
- * Call: \c cr_assert_float_neq(Actual, Unexpected, Epsilon, [FormatString,
- * [Args...]])
  *
  * Passes if Actual is not equal to Unexpected with a tolerance of Epsilon.
  * Otherwise the test is marked as failure and the execution of the function
@@ -558,17 +484,14 @@
  * @param[in] Actual Value to test
  * @param[in] Unexpected Unexpected value
  * @param[in] Epsilon Tolerance between Actual and Expected
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-# define cr_assert_float_neq(...) CR_EXPAND(cr_assert_float_op_va_(CR_FAIL_ABORT_,     cr_assert_float_neq_op_, __VA_ARGS__))
+# define cr_assert_float_neq(Actual, Unexpected, Epsilon, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is not equal to Unexpected with a tolerance of Epsilon
- *
- * Call: \c cr_expect_float_neq(Actual, Unexpected, Epsilon, [FormatString,
- * [Args...]])
  *
  * Passes if Actual is not equal to Unexpected with a tolerance of Epsilon.
  * Otherwise the test is marked as failure but the execution will continue.
@@ -580,25 +503,28 @@
  * @param[in] Actual Value to test
  * @param[in] Unexpected Unexpected value
  * @param[in] Epsilon Tolerance between Actual and Expected
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_expect_float_neq(...) CR_EXPAND(cr_assert_float_op_va_(CR_FAIL_CONTINUES_, cr_assert_float_neq_op_, __VA_ARGS__))
+# define cr_expect_float_neq(Actual, Unexpected, Epsilon, FormatString, ...) <internal>
 
 /**@}*/
 
 /**
  * @defgroup StringAsserts String assertions
+ *
+ * @note
+ * These macros are meant to deal with *native* strings, i.e. char arrays.
+ * Most of them won't work on ``std::string`` in C++, with some exceptions --
+ * for ``std::string``, you should use regular comparison assersions.
+ *
  * @{
  */
 
 /**
  * Passes if Value is an empty string
  *
- * Call: \c cr_assert_str_empty(Value, [FormatString, [Args...]])
- *
  * Passes if Value is an empty string.
  * Otherwise the test is marked as failure and the execution of the function
  * is aborted.
@@ -608,17 +534,15 @@
  * @note Also works on std::string.
  *
  * @param[in] Value String to test
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-# define cr_assert_str_empty(...) CR_EXPAND(cr_assert_str_op_empty_va_(CR_FAIL_ABORT_, ==, CRITERION_ASSERT_MSG_IS_NOT_EMPTY, __VA_ARGS__))
+# define cr_assert_str_empty(Value, FormatString, ...) <internal>
 
 /**
  * Passes if Value is an empty string
  *
- * Call: \c cr_expect_str_empty(Value, [FormatString, [Args...]])
- *
  * Passes if Value is an empty string.
  * Otherwise the test is marked as failure but the execution will continue.
  *
@@ -627,17 +551,14 @@
  * @note Also works on std::string.
  *
  * @param[in] Value String to test
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_expect_str_empty(...) CR_EXPAND(cr_assert_str_op_empty_va_(CR_FAIL_CONTINUES_, ==, CRITERION_ASSERT_MSG_IS_NOT_EMPTY, __VA_ARGS__))
+# define cr_expect_str_empty(Value, FormatString, ...) <internal>
 
 /**
  * Passes if Value is not an empty string
- *
- * Call: \c cr_assert_str_not_empty(Value, [FormatString, [Args...]])
  *
  * Passes if Value is not an empty string.
  * Otherwise the test is marked as failure and the execution of the function
@@ -648,16 +569,14 @@
  * @note Also works on std::string.
  *
  * @param[in] Value String to test
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-# define cr_assert_str_not_empty(...) CR_EXPAND(cr_assert_str_op_empty_va_(CR_FAIL_ABORT_, !=, CRITERION_ASSERT_MSG_IS_EMPTY, __VA_ARGS__))
+# define cr_assert_str_not_empty(Value, FormatString, ...) <internal>
 
 /**
  * Passes if Value is not an empty string
- *
- * Call: \c cr_expect_str_not_empty(Value, [FormatString, [Args...]])
  *
  * Passes if Value is not an empty string.
  * Otherwise the test is marked as failure but the execution will continue.
@@ -667,17 +586,14 @@
  * @note Also works on std::string.
  *
  * @param[in] Value String to test
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_expect_str_not_empty(...) CR_EXPAND(cr_assert_str_op_empty_va_(CR_FAIL_CONTINUES_, !=, CRITERION_ASSERT_MSG_IS_EMPTY, __VA_ARGS__))
+# define cr_expect_str_not_empty(Value, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is lexicographically equal to Expected
- *
- * Call: \c cr_assert_str_eq(Actual, Expected, [FormatString, [Args...]])
  *
  * Passes if Actual is lexicographically equal to Expected.
  * Otherwise the test is marked as failure and the execution of the function
@@ -687,16 +603,14 @@
  *
  * @param[in] Actual String to test
  * @param[in] Expected Expected String
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-# define cr_assert_str_eq(...) CR_EXPAND(cr_assert_str_op_va_(CR_FAIL_ABORT_,      ==, __VA_ARGS__))
+# define cr_assert_str_eq(Actual, Expected, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is lexicographically equal to Expected
- *
- * Call: \c cr_expect_str_eq(Actual, Expected, [FormatString, [Args...]])
  *
  * Passes if Actual is lexicographically equal to Expected.
  * Otherwise the test is marked as failure but the execution will continue.
@@ -705,17 +619,14 @@
  *
  * @param[in] Actual String to test
  * @param[in] Expected Expected String
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_expect_str_eq(...) CR_EXPAND(cr_assert_str_op_va_(CR_FAIL_CONTINUES_,  ==, __VA_ARGS__))
+# define cr_expect_str_eq(Actual, Expected, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is not lexicographically equal to Unexpected
- *
- * Call: \c cr_assert_str_neq(Actual, Unexpected, [FormatString, [Args...]])
  *
  * Passes if Actual is not lexicographically equal to Unexpected.
  * Otherwise the test is marked as failure and the execution of the function
@@ -725,16 +636,14 @@
  *
  * @param[in] Actual String to test
  * @param[in] Unexpected Unexpected String
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-# define cr_assert_str_neq(...) CR_EXPAND(cr_assert_str_op_va_(CR_FAIL_ABORT_,     !=, __VA_ARGS__))
+# define cr_assert_str_neq(Actual, Unexpected, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is not lexicographically equal to Unexpected
- *
- * Call: \c cr_expect_str_neq(Actual, Unexpected, [FormatString, [Args...]])
  *
  * Passes if Actual is not lexicographically equal to Unexpected.
  * Otherwise the test is marked as failure but the execution will continue.
@@ -743,17 +652,14 @@
  *
  * @param[in] Actual String to test
  * @param[in] Unexpected Unexpected String
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_expect_str_neq(...) CR_EXPAND(cr_assert_str_op_va_(CR_FAIL_CONTINUES_, !=, __VA_ARGS__))
+# define cr_expect_str_neq(Actual, Unexpected, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is lexicographically less than Reference
- *
- * Call: \c cr_assert_str_lt(Actual, Reference, [FormatString, [Args...]])
  *
  * Passes if Actual is lexicographically less than Reference.
  * Otherwise the test is marked as failure and the execution of the function
@@ -763,16 +669,14 @@
  *
  * @param[in] Actual String to test
  * @param[in] Reference Reference String
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-# define cr_assert_str_lt(...) CR_EXPAND(cr_assert_str_op_va_(CR_FAIL_ABORT_,      <, __VA_ARGS__))
+# define cr_assert_str_lt(Actual, Reference, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is lexicographically less than Reference
- *
- * Call: \c cr_expect_str_lt(Actual, Reference, [FormatString, [Args...]])
  *
  * Passes if Actual is lexicographically less than Reference.
  * Otherwise the test is marked as failure but the execution will continue.
@@ -781,17 +685,14 @@
  *
  * @param[in] Actual String to test
  * @param[in] Reference Reference String
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_expect_str_lt(...) CR_EXPAND(cr_assert_str_op_va_(CR_FAIL_CONTINUES_,  <, __VA_ARGS__))
+# define cr_expect_str_lt(Actual, Reference, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is lexicographically less or equal to Reference
- *
- * Call: \c cr_assert_str_leq(Actual, Reference, [FormatString, [Args...]])
  *
  * Passes if Actual is lexicographically less or equal to Reference.
  * Otherwise the test is marked as failure and the execution of the function
@@ -801,16 +702,14 @@
  *
  * @param[in] Actual String to test
  * @param[in] Reference Reference String
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-# define cr_assert_str_leq(...) CR_EXPAND(cr_assert_str_op_va_(CR_FAIL_ABORT_,     <=, __VA_ARGS__))
+# define cr_assert_str_leq(Actual, Reference, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is lexicographically less or equal to Reference
- *
- * Call: \c cr_expect_str_leq(Actual, Reference, [FormatString, [Args...]])
  *
  * Passes if Actual is lexicographically less or equal to Reference.
  * Otherwise the test is marked as failure but the execution will continue.
@@ -819,17 +718,14 @@
  *
  * @param[in] Actual String to test
  * @param[in] Reference Reference String
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_expect_str_leq(...) CR_EXPAND(cr_assert_str_op_va_(CR_FAIL_CONTINUES_, <=, __VA_ARGS__))
+# define cr_expect_str_leq(Actual, Reference, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is lexicographically greater than Reference
- *
- * Call: \c cr_assert_str_gt(Actual, Reference, [FormatString, [Args...]])
  *
  * Passes if Actual is lexicographically greater than Reference.
  * Otherwise the test is marked as failure and the execution of the function
@@ -839,16 +735,14 @@
  *
  * @param[in] Actual String to test
  * @param[in] Reference Reference String
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-# define cr_assert_str_gt(...) CR_EXPAND(cr_assert_str_op_va_(CR_FAIL_ABORT_,      >, __VA_ARGS__))
+# define cr_assert_str_gt(Actual, Reference, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is lexicographically greater than Reference
- *
- * Call: \c cr_expect_str_gt(Actual, Reference, [FormatString, [Args...]])
  *
  * Passes if Actual is lexicographically greater than Reference.
  * Otherwise the test is marked as failure but the execution will continue.
@@ -857,17 +751,14 @@
  *
  * @param[in] Actual String to test
  * @param[in] Reference Reference String
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-# define cr_expect_str_gt(...) CR_EXPAND(cr_assert_str_op_va_(CR_FAIL_CONTINUES_,  >, __VA_ARGS__))
-
+# define cr_expect_str_gt(Actual, Reference, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is lexicographically greater or equal to Reference
- *
- * Call: \c cr_assert_str_geq(Actual, Reference, [FormatString, [Args...]])
  *
  * Passes if Actual is lexicographically greater or equal to Reference.
  * Otherwise the test is marked as failure and the execution of the function
@@ -877,16 +768,14 @@
  *
  * @param[in] Actual String to test
  * @param[in] Reference Reference String
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-# define cr_assert_str_geq(...) CR_EXPAND(cr_assert_str_op_va_(CR_FAIL_ABORT_,     >=, __VA_ARGS__))
+# define cr_assert_str_geq(Actual, Reference, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is lexicographically greater or equal to Reference
- *
- * Call: \c cr_expect_str_geq(Actual, Reference, [FormatString, [Args...]])
  *
  * Passes if Actual is lexicographically greater or equal to Reference.
  * Otherwise the test is marked as failure but the execution will continue.
@@ -895,12 +784,11 @@
  *
  * @param[in] Actual String to test
  * @param[in] Reference Reference String
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_expect_str_geq(...) CR_EXPAND(cr_assert_str_op_va_(CR_FAIL_CONTINUES_, >=, __VA_ARGS__))
+# define cr_expect_str_geq(Actual, Reference, FormatString, ...) <internal>
 
 /**@}*/
 
@@ -911,8 +799,6 @@
 
 /**
  * Passes if Actual is byte-to-byte equal to Expected
- *
- * Call: \c cr_assert_arr_eq(Actual, Expected, [FormatString, [Args...]])
  *
  * Passes if Actual is byte-to-byte equal to Expected.
  * Otherwise the test is marked as failure and the execution of the function
@@ -925,16 +811,14 @@
  *
  * @param[in] Actual Array to test
  * @param[in] Expected Expected array
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-# define cr_assert_arr_eq(...) CR_EXPAND(cr_assert_mem_op_va_(CR_FAIL_ABORT_,      ==, __VA_ARGS__))
+# define cr_assert_arr_eq(Actual, Expected, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is byte-to-byte equal to Expected
- *
- * Call: \c cr_expect_arr_eq(Actual, Expected, [FormatString, [Args...]])
  *
  * Passes if Actual is byte-to-byte equal to Expected.
  * Otherwise the test is marked as failure but the execution will continue.
@@ -946,19 +830,14 @@
  *
  * @param[in] Actual Array to test
  * @param[in] Expected Expected array
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_expect_arr_eq(...) CR_EXPAND(cr_assert_mem_op_va_(CR_FAIL_CONTINUES_,  ==, __VA_ARGS__))
-
+# define cr_expect_arr_eq(Actual, Expected, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is not byte-to-byte equal to Expected
- *
- * Call: \c cr_assert_arr_neq(Actual, Unexpected, Size, [FormatString,
- * [Args...]])
  *
  * Passes if Actual is not byte-to-byte equal to Unexpected.
  * Otherwise the test is marked as failure and the execution of the function
@@ -972,17 +851,14 @@
  * @param[in] Actual Array to test
  * @param[in] Unexpected Unexpected array
  * @param[in] Size Number of bytes to check
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-# define cr_assert_arr_neq(...) CR_EXPAND(cr_assert_mem_op_va_(CR_FAIL_ABORT_,     !=, __VA_ARGS__))
+# define cr_assert_arr_neq(Actual, Unexpected, Size, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is not byte-to-byte equal to Unexpected
- *
- * Call: \c cr_expect_arr_neq(Actual, Unexpected, Size, [FormatString,
- * [Args...]])
  *
  * Passes if Actual is not byte-to-byte equal to Expected.
  * Otherwise the test is marked as failure but the execution will continue.
@@ -995,12 +871,11 @@
  * @param[in] Actual Array to test
  * @param[in] Unexpected Unexpected array
  * @param[in] Size Number of bytes to check
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_expect_arr_neq(...) CR_EXPAND(cr_assert_mem_op_va_(CR_FAIL_CONTINUES_, !=, __VA_ARGS__))
+# define cr_expect_arr_neq(Actual, Unexpected, Size, FormatString, ...) <internal>
 
 /**@}*/
 
@@ -1012,14 +887,8 @@
  * @{
  */
 
-# if defined(__GNUC__) || defined(__clang__) || defined(__cplusplus)
-
-
 /**
  * Passes if Actual is comparatively equal to Expected (C++ / GNU C99 only)
- *
- * Call: \c cr_assert_arr_eq_cmp(Actual, Expected, Size, Cmp, [FormatString,
- * [Args...]])
  *
  * Passes if Actual is comparatively equal to Expected.
  * Otherwise the test is marked as failure and the execution of the function
@@ -1034,17 +903,14 @@
  * @param[in] Size Number of bytes to check
  * @param[in] Cmp Function pointer to a function int fn(<type of Actual>,
  * <type of Expected>) to do the comparison
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-#  define cr_assert_arr_eq_cmp(...) CR_EXPAND(cr_assert_arr_op_cmp_va_(CR_FAIL_ABORT_,      ==, __VA_ARGS__))
+# define cr_assert_arr_eq_cmp(Actual, Expected, Size, Cmp, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is comparatively equal to Expected (C++ / GNU C99 only)
- *
- * Call: \c cr_expect_arr_eq_cmp(Actual, Expected, Size, Cmp, [FormatString,
- * [Args...]])
  *
  * Passes if Actual is comparatively equal to Expected.
  * Otherwise the test is marked as failure but the execution will continue.
@@ -1058,19 +924,15 @@
  * @param[in] Size Number of bytes to check
  * @param[in] Cmp Function pointer to a function int fn(<type of Actual>,
  * <type of Expected>) to do the comparison
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-#  define cr_expect_arr_eq_cmp(...) CR_EXPAND(cr_assert_arr_op_cmp_va_(CR_FAIL_CONTINUES_,  ==, __VA_ARGS__))
+# define cr_expect_arr_eq_cmp(Actual, Expected, Size, Cmp, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is not comparatively equal to Unexpected (C++ / GNU C99
  * only)
- *
- * Call: \c cr_assert_arr_neq_cmp(Actual, Unexpected, Size, Cmp, [FormatString,
- * [Args...]])
  *
  * Passes if Actual is not comparatively equal to Unexpected.
  * Otherwise the test is marked as failure and the execution of the function
@@ -1085,18 +947,15 @@
  * @param[in] Size Number of bytes to check
  * @param[in] Cmp Function pointer to a function int fn(<type of Actual>,
  * <type of Unexpected>) to do the comparison
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-#  define cr_assert_arr_neq_cmp(...) CR_EXPAND(cr_assert_arr_op_cmp_va_(CR_FAIL_ABORT_,     !=, __VA_ARGS__))
+# define cr_assert_arr_neq_cmp(Actual, Unexpected, Size, Cmp, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is not comparatively equal to Unexpected (C++ / GNU C99
  * only)
- *
- * Call: \c cr_expect_arr_neq_cmp(Actual, Unexpected, Size, Cmp, [FormatString,
- * [Args...]])
  *
  * Passes if Actual is not comparatively equal to Unexpected.
  * Otherwise the test is marked as failure but the execution will continue.
@@ -1110,18 +969,14 @@
  * @param[in] Size Number of bytes to check
  * @param[in] Cmp Function pointer to a function int fn(<type of Actual>,
  * <type of Unexpected>) to do the comparison
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-#  define cr_expect_arr_neq_cmp(...) CR_EXPAND(cr_assert_arr_op_cmp_va_(CR_FAIL_CONTINUES_, !=, __VA_ARGS__))
+# define cr_expect_arr_neq_cmp(Actual, Unexpected, Size, Cmp, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is comparatively less than Reference (C++ / GNU C99 only)
- *
- * Call: \c cr_assert_arr_lt_cmp(Actual, Reference, Size, Cmp, [FormatString,
- * [Args...]])
  *
  * Passes if Actual is  comparatively less than Reference.
  * Otherwise the test is marked as failure and the execution of the function
@@ -1136,17 +991,14 @@
  * @param[in] Size Number of bytes to check
  * @param[in] Cmp Function pointer to a function int fn(<type of Actual>,
  * <type of Reference>) to do the comparison
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-#  define cr_assert_arr_lt_cmp(...) CR_EXPAND(cr_assert_arr_op_cmp_va_(CR_FAIL_ABORT_,      <, __VA_ARGS__))
+# define cr_assert_arr_lt_cmp(Actual, Reference, Size, Cmp, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is comparatively less than Reference (C++ / GNU C99 only)
- *
- * Call: \c cr_expect_arr_lt_cmp(Actual, Reference, Size, Cmp, [FormatString,
- * [Args...]])
  *
  * Passes if Actual is  comparatively less than Reference.
  * Otherwise the test is marked as failure but the execution will continue.
@@ -1160,19 +1012,15 @@
  * @param[in] Size Number of bytes to check
  * @param[in] Cmp Function pointer to a function int fn(<type of Actual>,
  * <type of Reference>) to do the comparison
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-#  define cr_expect_arr_lt_cmp(...) CR_EXPAND(cr_assert_arr_op_cmp_va_(CR_FAIL_CONTINUES_,  <, __VA_ARGS__))
+# define cr_expect_arr_lt_cmp(Actual, Reference, Size, Cmp, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is comparatively less or equal to Reference (C++ / GNU C99
  * only)
- *
- * Call: \c cr_assert_arr_leq_cmp(Actual, Reference, Size, Cmp, [FormatString,
- * [Args...]])
  *
  * Passes if Actual is  comparatively less or equal to Reference.
  * Otherwise the test is marked as failure and the execution of the function
@@ -1187,18 +1035,15 @@
  * @param[in] Size Number of bytes to check
  * @param[in] Cmp Function pointer to a function int fn(<type of Actual>,
  * <type of Reference>) to do the comparison
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-#  define cr_assert_arr_leq_cmp(...) CR_EXPAND(cr_assert_arr_op_cmp_va_(CR_FAIL_ABORT_,     <=, __VA_ARGS__))
+# define cr_assert_arr_leq_cmp(Actual, Reference, Size, Cmp, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is comparatively less or equal to Reference (C++ / GNU C99
  * only)
- *
- * Call: \c cr_expect_arr_leq_cmp(Actual, Reference, Size, Cmp, [FormatString,
- * [Args...]])
  *
  * Passes if Actual is  comparatively less or equal to Reference.
  * Otherwise the test is marked as failure but the execution will continue.
@@ -1212,18 +1057,14 @@
  * @param[in] Size Number of bytes to check
  * @param[in] Cmp Function pointer to a function int fn(<type of Actual>,
  * <type of Reference>) to do the comparison
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-#  define cr_expect_arr_leq_cmp(...) CR_EXPAND(cr_assert_arr_op_cmp_va_(CR_FAIL_CONTINUES_, <=, __VA_ARGS__))
+# define cr_expect_arr_leq_cmp(Actual, Reference, Size, Cmp, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is comparatively greater than Reference (C++ / GNU C99 only)
- *
- * Call: \c cr_assert_arr_gt_cmp(Actual, Reference, Size, Cmp, [FormatString,
- * [Args...]])
  *
  * Passes if Actual is  comparatively greater than Reference.
  * Otherwise the test is marked as failure and the execution of the function
@@ -1238,17 +1079,14 @@
  * @param[in] Size Number of bytes to check
  * @param[in] Cmp Function pointer to a function int fn(<type of Actual>,
  * <type of Reference>) to do the comparison
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-#  define cr_assert_arr_gt_cmp(...) CR_EXPAND(cr_assert_arr_op_cmp_va_(CR_FAIL_ABORT_,      >, __VA_ARGS__))
+# define cr_assert_arr_gt_cmp(Actual, Reference, Size, Cmp, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is comparatively greater than Reference (C++ / GNU C99 only)
- *
- * Call: \c cr_expect_arr_gt_cmp(Actual, Reference, Size, Cmp, [FormatString,
- * [Args...]])
  *
  * Passes if Actual is  comparatively greater than Reference.
  * Otherwise the test is marked as failure but the execution will continue.
@@ -1262,19 +1100,15 @@
  * @param[in] Size Number of bytes to check
  * @param[in] Cmp Function pointer to a function int fn(<type of Actual>,
  * <type of Reference>) to do the comparison
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-#  define cr_expect_arr_gt_cmp(...) CR_EXPAND(cr_assert_arr_op_cmp_va_(CR_FAIL_CONTINUES_,  >, __VA_ARGS__))
+# define cr_expect_arr_gt_cmp(Actual, Reference, Size, Cmp, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is comparatively greater or equal to Reference (C++ / GNU
  * C99 only)
- *
- * Call: \c cr_assert_arr_geq_cmp(Actual, Reference, Size, Cmp, [FormatString,
- * [Args...]])
  *
  * Passes if Actual is  comparatively greater or equal to Reference.
  * Otherwise the test is marked as failure and the execution of the function
@@ -1289,18 +1123,15 @@
  * @param[in] Size Number of bytes to check
  * @param[in] Cmp Function pointer to a function int fn(<type of Actual>,
  * <type of Reference>) to do the comparison
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-#  define cr_assert_arr_geq_cmp(...) CR_EXPAND(cr_assert_arr_op_cmp_va_(CR_FAIL_ABORT_,     >=, __VA_ARGS__))
+# define cr_assert_arr_geq_cmp(Actual, Reference, Size, Cmp, FormatString, ...) <internal>
 
 /**
  * Passes if Actual is comparatively greater or equal to Reference (C++ / GNU
  * C99 only)
- *
- * Call: \c cr_expect_arr_geq_cmp(Actual, Reference, Size, Cmp, [FormatString,
- * [Args...]])
  *
  * Passes if Actual is  comparatively greater or equal to Reference.
  * Otherwise the test is marked as failure but the execution will continue.
@@ -1314,39 +1145,15 @@
  * @param[in] Size Number of bytes to check
  * @param[in] Cmp Function pointer to a function int fn(<type of Actual>,
  * <type of Reference>) to do the comparison
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
+# define cr_expect_arr_geq_cmp(Actual, Reference, Size, Cmp, FormatString, ...) <internal>
 
-#  define cr_expect_arr_geq_cmp(...) CR_EXPAND(cr_assert_arr_op_cmp_va_(CR_FAIL_CONTINUES_, >=, __VA_ARGS__))
-
-
-# else
-
-#  define cr_assert_arr_eq_cmp(...) CRITERION_GNUC_WARN_(cr_assert_arr_eq_cmp) CR_NOOP
-#  define cr_expect_arr_eq_cmp(...) CRITERION_GNUC_WARN_(cr_expect_arr_eq_cmp) CR_NOOP
-
-#  define cr_assert_arr_neq_cmp(...) CRITERION_GNUC_WARN_(cr_assert_arr_neq_cmp) CR_NOOP
-#  define cr_expect_arr_neq_cmp(...) CRITERION_GNUC_WARN_(cr_expect_arr_neq_cmp) CR_NOOP
-
-#  define cr_assert_arr_lt_cmp(...) CRITERION_GNUC_WARN_(cr_assert_arr_lt_cmp) CR_NOOP
-#  define cr_expect_arr_lt_cmp(...) CRITERION_GNUC_WARN_(cr_expect_arr_lt_cmp) CR_NOOP
-
-#  define cr_assert_arr_leq_cmp(...) CRITERION_GNUC_WARN_(cr_assert_arr_leq_cmp) CR_NOOP
-#  define cr_expect_arr_leq_cmp(...) CRITERION_GNUC_WARN_(cr_expect_arr_leq_cmp) CR_NOOP
-
-#  define cr_assert_arr_gt_cmp(...) CRITERION_GNUC_WARN_(cr_assert_arr_gt_cmp) CR_NOOP
-#  define cr_expect_arr_gt_cmp(...) CRITERION_GNUC_WARN_(cr_expect_arr_gt_cmp) CR_NOOP
-
-#  define cr_assert_arr_geq_cmp(...) CRITERION_GNUC_WARN_(cr_assert_arr_geq_cmp) CR_NOOP
-#  define cr_expect_arr_geq_cmp(...) CRITERION_GNUC_WARN_(cr_expect_arr_geq_cmp) CR_NOOP
-
-# endif
 /**@}*/
 
 # ifdef __cplusplus
-
 
 /**
  * @defgroup ExceptionAsserts Exception asserts
@@ -1359,8 +1166,6 @@
 /**
  * Passes if Statement throws an instance of Exception (C++ only)
  *
- * Call: \c cr_assert_throw(Statement, Exception, [FormatString, [Args...]])
- *
  * Passes if Statement throws an instance of Exception.
  * Otherwise the test is marked as failure and the execution of the function
  * is aborted.
@@ -1371,17 +1176,15 @@
  *
  * @param[in] Statement Statement to be executed
  * @param[in] Exception Expected exception
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-#  define cr_assert_throw(...) CR_EXPAND(cr_assert_throw_va_(CR_FAIL_ABORT_,     __VA_ARGS__))
+#  define cr_assert_throw(Statement, Exception, FormatString, ...) <internal>
 
 /**
  * Passes if Statement throws an instance of Exception (C++ only)
  *
- * Call: \c cr_assert_throw(Statement, Exception, [FormatString, [Args...]])
- *
  * Passes if Statement throws an instance of Exception.
  * Otherwise the test is marked as failure but the execution will continue.
  *
@@ -1391,17 +1194,14 @@
  *
  * @param[in] Statement Statement to be executed
  * @param[in] Exception Expected exception
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-#  define cr_expect_throw(...) CR_EXPAND(cr_assert_throw_va_(CR_FAIL_CONTINUES_, __VA_ARGS__))
+#  define cr_expect_throw(Statement, Exception, FormatString, ...) <internal>
 
 /**
  * Passes if Statement does not throws an instance of Exception (C++ only)
- *
- * Call: \c cr_assert_no_throw(Statement, Exception, [FormatString,
- * [Args...]])
  *
  * Passes if Statement does not throws an instance of Exception.
  * Otherwise the test is marked as failure and the execution of the function
@@ -1413,17 +1213,14 @@
  *
  * @param[in] Statement Statement to be executed
  * @param[in] Exception Unexpected exception
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-#  define cr_assert_no_throw(...) CR_EXPAND(cr_assert_no_throw_va_(CR_FAIL_ABORT_,     __VA_ARGS__))
+#  define cr_assert_no_throw(Statement, Exception, FormatString, ...) <internal>
 
 /**
  * Passes if Statement does not throws an instance of Exception (C++ only)
- *
- * Call: \c cr_assert_no_throw(Statement, Exception, [FormatString,
- * [Args...]])
  *
  * Passes if Statement does not throws an instance of Exception.
  * Otherwise the test is marked as failure but the execution will continue.
@@ -1434,18 +1231,14 @@
  *
  * @param[in] Statement Statement to be executed
  * @param[in] Exception Unexpected exception
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-#  define cr_expect_no_throw(...) CR_EXPAND(cr_assert_no_throw_va_(CR_FAIL_CONTINUES_, __VA_ARGS__))
-
+#  define cr_expect_no_throw(Statement, Exception, FormatString, ...) <internal>
 
 /**
  * Passes if Statement throws any kind of exception (C++ only)
- *
- * Call: \c cr_assert_any_throw(Statement, [FormatString, [Args...]])
  *
  * Passes if Statement throws any kind of exception
  * Otherwise the test is marked as failure and the execution of the function
@@ -1456,16 +1249,14 @@
  * @note This macro is only available on C++ compilers.
  *
  * @param[in] Statement Statement to be executed
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-#  define cr_assert_any_throw(...) CR_EXPAND(cr_assert_any_throw_va_(CR_FAIL_ABORT_,     __VA_ARGS__))
+#  define cr_assert_any_throw(Statement, FormatString, ...) <internal>
 
 /**
  * Passes if Statement throws any kind of exception (C++ only)
- *
- * Call: \c cr_assert_any_throw(Statement, [FormatString, [Args...]])
  *
  * Passes if Statement throws any kind of exception
  * Otherwise the test is marked as failure but the execution will continue.
@@ -1475,17 +1266,14 @@
  * @note This macro is only available on C++ compilers.
  *
  * @param[in] Statement Statement to be executed
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-#  define cr_expect_any_throw(...) CR_EXPAND(cr_assert_any_throw_va_(CR_FAIL_CONTINUES_, __VA_ARGS__))
+#  define cr_expect_any_throw(Statement, FormatString, ...) <internal>
 
 /**
  * Passes if Statement does not throws any kind of exception (C++ only)
- *
- * Call: \c cr_assert_any_throw(Statement, [FormatString, [Args...]])
  *
  * Passes if Statement does not throws any kind of exception
  * Otherwise the test is marked as failure and the execution of the function
@@ -1496,16 +1284,14 @@
  * @note This macro is only available on C++ compilers.
  *
  * @param[in] Statement Statement to be executed
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-#  define cr_assert_none_throw(...) CR_EXPAND(cr_assert_none_throw_va_(CR_FAIL_ABORT_,     __VA_ARGS__))
+#  define cr_assert_none_throw(Statement, FormatString, ...) <internal>
 
 /**
  * Passes if Statement does not throws any kind of exception (C++ only)
- *
- * Call: \c cr_assert_any_throw(Statement, [FormatString, [Args...]])
  *
  * Passes if Statement does not throws any kind of exception
  * Otherwise the test is marked as failure but the execution will continue.
@@ -1515,12 +1301,11 @@
  * @note This macro is only available on C++ compilers.
  *
  * @param[in] Statement Statement to be executed
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-#  define cr_expect_none_throw(...) CR_EXPAND(cr_assert_none_throw_va_(CR_FAIL_CONTINUES_, __VA_ARGS__))
+#  define cr_expect_none_throw(Statement, FormatString, ...) <internal>
 
 # endif
 /**@}*/
@@ -1560,5 +1345,7 @@
 #  define cr_assert_arrays_neq_cmp(...) CRITERION_ASSERT_DEPRECATED_B(cr_assert_arrays_neq_cmp, cr_assert_arr_neq_cmp) cr_assert_arr_neq_cmp(__VA_ARGS__)
 
 # endif
+
+# include "internal/assert.h"
 
 #endif /* !CRITERION_ASSERT_H_ */

--- a/include/criterion/assert.h
+++ b/include/criterion/assert.h
@@ -1346,6 +1346,8 @@
 # endif
 /**@}*/
 
+/** @cond CRITERION_DOC_DEPRECATED */
+
 // The section below is here for backward compatibility purposes.
 // It shall be removed in the next major version of Criterion
 # ifndef CRITERION_NO_COMPAT
@@ -1381,6 +1383,8 @@
 #  define cr_assert_arrays_neq_cmp(...) CRITERION_ASSERT_DEPRECATED_B(cr_assert_arrays_neq_cmp, cr_assert_arr_neq_cmp) cr_assert_arr_neq_cmp(__VA_ARGS__)
 
 # endif
+
+/** @endcond */
 
 # include "internal/assert.h"
 

--- a/include/criterion/criterion.h
+++ b/include/criterion/criterion.h
@@ -32,34 +32,28 @@
 # include "assert.h"
 # include "alloc.h"
 
-# include "internal/test.h"
-
 /**
- *  Test(Suite, Name, [Options...]) { Function body }
- *
  *  Defines a new test.
  *
  *  @param Suite   The name of the test suite containing this test.
  *  @param Name    The name of the test.
- *  @param Options An optional sequence of designated initializer key/value
+ *  @param ...     An optional sequence of designated initializer key/value
  *    pairs as described in the `criterion_test_extra_data` structure
- *    (see criterion/types.h).
+ *    (see criterion/types.h).\n
  *    Example: .exit_code = 1
  */
-# define Test(...) CR_EXPAND(CR_TEST_BASE(__VA_ARGS__, .sentinel_ = 0))
+# define Test(Suite, Name, ...) <internal>
 
 /**
- *  TestSuite(Name, [Options...]);
- *
  *  Explicitely defines a test suite and its options.
  *
- *  @param Name    The name of the test suite.
- *  @param Options An optional sequence of designated initializer key/value
+ *  @param Name The name of the test suite.
+ *  @param ...  An optional sequence of designated initializer key/value
  *    pairs as described in the `criterion_test_extra_data` structure
  *    (see criterion/types.h).
  *    These options will provide the defaults for each test.
  */
-# define TestSuite(...) CR_EXPAND(CR_SUITE_BASE(__VA_ARGS__, .sentinel_ = 0))
+# define TestSuite(Name, ...) <internal>
 
 CR_BEGIN_C_API
 
@@ -121,5 +115,7 @@ extern const struct criterion_test  *const criterion_current_test;
 extern const struct criterion_suite *const criterion_current_suite;
 
 CR_END_C_API
+
+# include "internal/test.h"
 
 #endif /* !CRITERION_H_ */

--- a/include/criterion/internal/assert.h
+++ b/include/criterion/internal/assert.h
@@ -80,12 +80,6 @@ CR_END_C_API
 # define CR_GET_CONDITION_STR(Condition, ...) #Condition
 # define CR_VA_SKIP(_, ...) __VA_ARGS__
 
-# ifdef __cplusplus
-#  define CR_STDN std::
-# else
-#  define CR_STDN
-# endif
-
 # define CR_TRANSLATE_DEF_MSG__(Arg) \
     CR_IDENTITY Arg
 

--- a/include/criterion/internal/assert.h
+++ b/include/criterion/internal/assert.h
@@ -460,4 +460,172 @@ CR_END_C_API
         "The `" #Name "` macro is only available on GNU C compilers."   \
     )
 
+// Actual implementation
+
+# undef cr_assert_fail
+# define cr_assert_fail(...) CR_EXPAND(cr_fail(CR_FAIL_ABORT_,     __VA_ARGS__))
+# undef cr_expect_fail
+# define cr_expect_fail(...) CR_EXPAND(cr_fail(CR_FAIL_CONTINUES_, __VA_ARGS__))
+# undef cr_assert
+# define cr_assert(...) CR_EXPAND(cr_assert_(__VA_ARGS__))
+# undef cr_expect
+# define cr_expect(...) CR_EXPAND(cr_expect_(__VA_ARGS__))
+# undef cr_assert_not
+# define cr_assert_not(...) CR_EXPAND(cr_assert_not_(__VA_ARGS__))
+# undef cr_expect_not
+# define cr_expect_not(...) CR_EXPAND(cr_expect_not_(__VA_ARGS__))
+# undef cr_assert_eq
+# define cr_assert_eq(...) CR_EXPAND(cr_assert_op_va_(CR_FAIL_ABORT_,      ==, __VA_ARGS__))
+# undef cr_expect_eq
+# define cr_expect_eq(...) CR_EXPAND(cr_assert_op_va_(CR_FAIL_CONTINUES_,  ==, __VA_ARGS__))
+# undef cr_assert_neq
+# define cr_assert_neq(...) CR_EXPAND(cr_assert_op_va_(CR_FAIL_ABORT_,     !=, __VA_ARGS__))
+# undef cr_expect_neq
+# define cr_expect_neq(...) CR_EXPAND(cr_assert_op_va_(CR_FAIL_CONTINUES_, !=, __VA_ARGS__))
+# undef cr_assert_lt
+# define cr_assert_lt(...) CR_EXPAND(cr_assert_op_va_(CR_FAIL_ABORT_,      <, __VA_ARGS__))
+# undef cr_expect_lt
+# define cr_expect_lt(...) CR_EXPAND(cr_assert_op_va_(CR_FAIL_CONTINUES_,  <, __VA_ARGS__))
+# undef cr_assert_leq
+# define cr_assert_leq(...) CR_EXPAND(cr_assert_op_va_(CR_FAIL_ABORT_,     <=, __VA_ARGS__))
+# undef cr_expect_leq
+# define cr_expect_leq(...) CR_EXPAND(cr_assert_op_va_(CR_FAIL_CONTINUES_, <=, __VA_ARGS__))
+# undef cr_assert_gt
+# define cr_assert_gt(...) CR_EXPAND(cr_assert_op_va_(CR_FAIL_ABORT_,      >, __VA_ARGS__))
+# undef cr_expect_gt
+# define cr_expect_gt(...) CR_EXPAND(cr_assert_op_va_(CR_FAIL_CONTINUES_,  >, __VA_ARGS__))
+# undef cr_assert_geq
+# define cr_assert_geq(...) CR_EXPAND(cr_assert_op_va_(CR_FAIL_ABORT_,     >=, __VA_ARGS__))
+# undef cr_expect_geq
+# define cr_expect_geq(...) CR_EXPAND(cr_assert_op_va_(CR_FAIL_CONTINUES_, >=, __VA_ARGS__))
+# undef cr_assert_null
+# define cr_assert_null(...) CR_EXPAND(cr_assert_null_op_va_(CR_FAIL_ABORT_,     ==, CRITERION_ASSERT_MSG_IS_NOT_NULL, __VA_ARGS__))
+# undef cr_expect_null
+# define cr_expect_null(...) CR_EXPAND(cr_assert_null_op_va_(CR_FAIL_CONTINUES_, ==, CRITERION_ASSERT_MSG_IS_NOT_NULL, __VA_ARGS__))
+# undef cr_assert_not_null
+# define cr_assert_not_null(...) CR_EXPAND(cr_assert_null_op_va_(CR_FAIL_ABORT_,     !=, CRITERION_ASSERT_MSG_IS_NULL, __VA_ARGS__))
+# undef cr_expect_not_null
+# define cr_expect_not_null(...) CR_EXPAND(cr_assert_null_op_va_(CR_FAIL_CONTINUES_, !=, CRITERION_ASSERT_MSG_IS_NULL, __VA_ARGS__))
+# undef cr_assert_float_eq
+# define cr_assert_float_eq(...) CR_EXPAND(cr_assert_float_op_va_(CR_FAIL_ABORT_,     cr_assert_float_eq_op_, __VA_ARGS__))
+# undef cr_expect_float_eq
+# define cr_expect_float_eq(...) CR_EXPAND(cr_assert_float_op_va_(CR_FAIL_CONTINUES_, cr_assert_float_eq_op_, __VA_ARGS__))
+# undef cr_assert_float_neq
+# define cr_assert_float_neq(...) CR_EXPAND(cr_assert_float_op_va_(CR_FAIL_ABORT_,     cr_assert_float_neq_op_, __VA_ARGS__))
+# undef cr_expect_float_neq
+# define cr_expect_float_neq(...) CR_EXPAND(cr_assert_float_op_va_(CR_FAIL_CONTINUES_, cr_assert_float_neq_op_, __VA_ARGS__))
+# undef cr_assert_str_empty
+# define cr_assert_str_empty(...) CR_EXPAND(cr_assert_str_op_empty_va_(CR_FAIL_ABORT_, ==, CRITERION_ASSERT_MSG_IS_NOT_EMPTY, __VA_ARGS__))
+# undef cr_expect_str_empty
+# define cr_expect_str_empty(...) CR_EXPAND(cr_assert_str_op_empty_va_(CR_FAIL_CONTINUES_, ==, CRITERION_ASSERT_MSG_IS_NOT_EMPTY, __VA_ARGS__))
+# undef cr_assert_str_not_empty
+# define cr_assert_str_not_empty(...) CR_EXPAND(cr_assert_str_op_empty_va_(CR_FAIL_ABORT_, !=, CRITERION_ASSERT_MSG_IS_EMPTY, __VA_ARGS__))
+# undef cr_expect_str_not_empty
+# define cr_expect_str_not_empty(...) CR_EXPAND(cr_assert_str_op_empty_va_(CR_FAIL_CONTINUES_, !=, CRITERION_ASSERT_MSG_IS_EMPTY, __VA_ARGS__))
+# undef cr_assert_str_eq
+# define cr_assert_str_eq(...) CR_EXPAND(cr_assert_str_op_va_(CR_FAIL_ABORT_,      ==, __VA_ARGS__))
+# undef cr_expect_str_eq
+# define cr_expect_str_eq(...) CR_EXPAND(cr_assert_str_op_va_(CR_FAIL_CONTINUES_,  ==, __VA_ARGS__))
+# undef cr_assert_str_neq
+# define cr_assert_str_neq(...) CR_EXPAND(cr_assert_str_op_va_(CR_FAIL_ABORT_,     !=, __VA_ARGS__))
+# undef cr_expect_str_neq
+# define cr_expect_str_neq(...) CR_EXPAND(cr_assert_str_op_va_(CR_FAIL_CONTINUES_, !=, __VA_ARGS__))
+# undef cr_assert_str_lt
+# define cr_assert_str_lt(...) CR_EXPAND(cr_assert_str_op_va_(CR_FAIL_ABORT_,      <, __VA_ARGS__))
+# undef cr_expect_str_lt
+# define cr_expect_str_lt(...) CR_EXPAND(cr_assert_str_op_va_(CR_FAIL_CONTINUES_,  <, __VA_ARGS__))
+# undef cr_assert_str_leq
+# define cr_assert_str_leq(...) CR_EXPAND(cr_assert_str_op_va_(CR_FAIL_ABORT_,     <=, __VA_ARGS__))
+# undef cr_expect_str_leq
+# define cr_expect_str_leq(...) CR_EXPAND(cr_assert_str_op_va_(CR_FAIL_CONTINUES_, <=, __VA_ARGS__))
+# undef cr_assert_str_gt
+# define cr_assert_str_gt(...) CR_EXPAND(cr_assert_str_op_va_(CR_FAIL_ABORT_,      >, __VA_ARGS__))
+# undef cr_expect_str_gt
+# define cr_expect_str_gt(...) CR_EXPAND(cr_assert_str_op_va_(CR_FAIL_CONTINUES_,  >, __VA_ARGS__))
+# undef cr_assert_str_geq
+# define cr_assert_str_geq(...) CR_EXPAND(cr_assert_str_op_va_(CR_FAIL_ABORT_,     >=, __VA_ARGS__))
+# undef cr_expect_str_geq
+# define cr_expect_str_geq(...) CR_EXPAND(cr_assert_str_op_va_(CR_FAIL_CONTINUES_, >=, __VA_ARGS__))
+# undef cr_assert_arr_eq
+# define cr_assert_arr_eq(...) CR_EXPAND(cr_assert_mem_op_va_(CR_FAIL_ABORT_,      ==, __VA_ARGS__))
+# undef cr_expect_arr_eq
+# define cr_expect_arr_eq(...) CR_EXPAND(cr_assert_mem_op_va_(CR_FAIL_CONTINUES_,  ==, __VA_ARGS__))
+# undef cr_assert_arr_neq
+# define cr_assert_arr_neq(...) CR_EXPAND(cr_assert_mem_op_va_(CR_FAIL_ABORT_,     !=, __VA_ARGS__))
+# undef cr_expect_arr_neq
+# define cr_expect_arr_neq(...) CR_EXPAND(cr_assert_mem_op_va_(CR_FAIL_CONTINUES_, !=, __VA_ARGS__))
+
+# if defined(__GNUC__) || defined(__clang__) || defined(__cplusplus)
+
+#  undef cr_assert_arr_eq_cmp
+#  define cr_assert_arr_eq_cmp(...) CR_EXPAND(cr_assert_arr_op_cmp_va_(CR_FAIL_ABORT_,      ==, __VA_ARGS__))
+#  undef cr_expect_arr_eq_cmp
+#  define cr_expect_arr_eq_cmp(...) CR_EXPAND(cr_assert_arr_op_cmp_va_(CR_FAIL_CONTINUES_,  ==, __VA_ARGS__))
+#  undef cr_assert_arr_neq_cmp
+#  define cr_assert_arr_neq_cmp(...) CR_EXPAND(cr_assert_arr_op_cmp_va_(CR_FAIL_ABORT_,     !=, __VA_ARGS__))
+#  undef cr_expect_arr_neq_cmp
+#  define cr_expect_arr_neq_cmp(...) CR_EXPAND(cr_assert_arr_op_cmp_va_(CR_FAIL_CONTINUES_, !=, __VA_ARGS__))
+#  undef cr_assert_arr_lt_cmp
+#  define cr_assert_arr_lt_cmp(...) CR_EXPAND(cr_assert_arr_op_cmp_va_(CR_FAIL_ABORT_,      <, __VA_ARGS__))
+#  undef cr_expect_arr_lt_cmp
+#  define cr_expect_arr_lt_cmp(...) CR_EXPAND(cr_assert_arr_op_cmp_va_(CR_FAIL_CONTINUES_,  <, __VA_ARGS__))
+#  undef cr_assert_arr_leq_cmp
+#  define cr_assert_arr_leq_cmp(...) CR_EXPAND(cr_assert_arr_op_cmp_va_(CR_FAIL_ABORT_,     <=, __VA_ARGS__))
+#  undef cr_expect_arr_leq_cmp
+#  define cr_expect_arr_leq_cmp(...) CR_EXPAND(cr_assert_arr_op_cmp_va_(CR_FAIL_CONTINUES_, <=, __VA_ARGS__))
+#  undef cr_assert_arr_gt_cmp
+#  define cr_assert_arr_gt_cmp(...) CR_EXPAND(cr_assert_arr_op_cmp_va_(CR_FAIL_ABORT_,      >, __VA_ARGS__))
+#  undef cr_expect_arr_gt_cmp
+#  define cr_expect_arr_gt_cmp(...) CR_EXPAND(cr_assert_arr_op_cmp_va_(CR_FAIL_CONTINUES_,  >, __VA_ARGS__))
+#  undef cr_assert_arr_geq_cmp
+#  define cr_assert_arr_geq_cmp(...) CR_EXPAND(cr_assert_arr_op_cmp_va_(CR_FAIL_ABORT_,     >=, __VA_ARGS__))
+#  undef cr_expect_arr_geq_cmp
+#  define cr_expect_arr_geq_cmp(...) CR_EXPAND(cr_assert_arr_op_cmp_va_(CR_FAIL_CONTINUES_, >=, __VA_ARGS__))
+
+# else
+
+#  undef cr_assert_arr_eq_cmp
+#  define cr_assert_arr_eq_cmp(...) CRITERION_GNUC_WARN_(cr_assert_arr_eq_cmp) CR_NOOP
+#  undef cr_expect_arr_eq_cmp
+#  define cr_expect_arr_eq_cmp(...) CRITERION_GNUC_WARN_(cr_expect_arr_eq_cmp) CR_NOOP
+#  undef cr_assert_arr_neq_cmp
+#  define cr_assert_arr_neq_cmp(...) CRITERION_GNUC_WARN_(cr_assert_arr_neq_cmp) CR_NOOP
+#  undef cr_expect_arr_neq_cmp
+#  define cr_expect_arr_neq_cmp(...) CRITERION_GNUC_WARN_(cr_expect_arr_neq_cmp) CR_NOOP
+#  undef cr_assert_arr_lt_cmp
+#  define cr_assert_arr_lt_cmp(...) CRITERION_GNUC_WARN_(cr_assert_arr_lt_cmp) CR_NOOP
+#  undef cr_expect_arr_lt_cmp
+#  define cr_expect_arr_lt_cmp(...) CRITERION_GNUC_WARN_(cr_expect_arr_lt_cmp) CR_NOOP
+#  undef cr_assert_arr_leq_cmp
+#  define cr_assert_arr_leq_cmp(...) CRITERION_GNUC_WARN_(cr_assert_arr_leq_cmp) CR_NOOP
+#  undef cr_expect_arr_leq_cmp
+#  define cr_expect_arr_leq_cmp(...) CRITERION_GNUC_WARN_(cr_expect_arr_leq_cmp) CR_NOOP
+#  undef cr_assert_arr_gt_cmp
+#  define cr_assert_arr_gt_cmp(...) CRITERION_GNUC_WARN_(cr_assert_arr_gt_cmp) CR_NOOP
+#  undef cr_expect_arr_gt_cmp
+#  define cr_expect_arr_gt_cmp(...) CRITERION_GNUC_WARN_(cr_expect_arr_gt_cmp) CR_NOOP
+#  undef cr_assert_arr_geq_cmp
+#  define cr_assert_arr_geq_cmp(...) CRITERION_GNUC_WARN_(cr_assert_arr_geq_cmp) CR_NOOP
+#  undef cr_expect_arr_geq_cmp
+#  define cr_expect_arr_geq_cmp(...) CRITERION_GNUC_WARN_(cr_expect_arr_geq_cmp) CR_NOOP
+
+# endif
+
+# undef cr_assert_throw
+# define cr_assert_throw(...) CR_EXPAND(cr_assert_throw_va_(CR_FAIL_ABORT_,     __VA_ARGS__))
+# undef cr_expect_throw
+# define cr_expect_throw(...) CR_EXPAND(cr_assert_throw_va_(CR_FAIL_CONTINUES_, __VA_ARGS__))
+# undef cr_assert_no_throw
+# define cr_assert_no_throw(...) CR_EXPAND(cr_assert_no_throw_va_(CR_FAIL_ABORT_,     __VA_ARGS__))
+# undef cr_expect_no_throw
+# define cr_expect_no_throw(...) CR_EXPAND(cr_assert_no_throw_va_(CR_FAIL_CONTINUES_, __VA_ARGS__))
+# undef cr_assert_any_throw
+# define cr_assert_any_throw(...) CR_EXPAND(cr_assert_any_throw_va_(CR_FAIL_ABORT_,     __VA_ARGS__))
+# undef cr_expect_any_throw
+# define cr_expect_any_throw(...) CR_EXPAND(cr_assert_any_throw_va_(CR_FAIL_CONTINUES_, __VA_ARGS__))
+# undef cr_assert_none_throw
+# define cr_assert_none_throw(...) CR_EXPAND(cr_assert_none_throw_va_(CR_FAIL_ABORT_,     __VA_ARGS__))
+# undef cr_expect_none_throw
+# define cr_expect_none_throw(...) CR_EXPAND(cr_assert_none_throw_va_(CR_FAIL_CONTINUES_, __VA_ARGS__))
+
 #endif /* !CRITERION_INTERNAL_ASSERT_H_ */

--- a/include/criterion/internal/common.h
+++ b/include/criterion/internal/common.h
@@ -151,4 +151,10 @@
 #  endif
 # endif
 
+# ifdef __cplusplus
+#  define CR_STDN std::
+# else
+#  define CR_STDN
+# endif
+
 #endif /* !CRITERION_COMMON_H_ */

--- a/include/criterion/internal/parameterized.h
+++ b/include/criterion/internal/parameterized.h
@@ -112,4 +112,13 @@ struct criterion_test_params {
     (struct criterion_test_params) { .size = sizeof (Type), (void*)(Array), __VA_ARGS__ }
 # endif
 
+# undef ParameterizedTest
+# define ParameterizedTest(...) CR_EXPAND(CR_PARAM_TEST_BASE(__VA_ARGS__, .sentinel_ = 0))
+
+# undef ParameterizedTestParameters
+# define ParameterizedTestParameters(Suite, Name) CR_PARAM_TEST_PARAMS(Suite, Name)
+
+# undef cr_make_param_array
+# define cr_make_param_array(...) CR_EXPAND(cr_make_param_array_(__VA_ARGS__))
+
 #endif /* !CRITERION_INTERNAL_PARAMETERIZED_H_ */

--- a/include/criterion/internal/redirect.h
+++ b/include/criterion/internal/redirect.h
@@ -67,5 +67,53 @@
             CR_VA_TAIL(CR_VA_TAIL(__VA_ARGS__))                 \
     ))
 
+# undef cr_assert_file_contents_eq_str
+# define cr_assert_file_contents_eq_str(...) CR_EXPAND(cr_assert_redir_op_va_(CR_FAIL_ABORT_,     cr_file_match_str, ==, __VA_ARGS__))
+# undef cr_expect_file_contents_eq_str
+# define cr_expect_file_contents_eq_str(...) CR_EXPAND(cr_assert_redir_op_va_(CR_FAIL_CONTINUES_, cr_file_match_str, ==, __VA_ARGS__))
+# undef cr_assert_file_contents_neq_str
+# define cr_assert_file_contents_neq_str(...) CR_EXPAND(cr_assert_redir_op_va_(CR_FAIL_ABORT_,     cr_file_match_str, !=, __VA_ARGS__))
+# undef cr_expect_file_contents_neq_str
+# define cr_expect_file_contents_neq_str(...) CR_EXPAND(cr_assert_redir_op_va_(CR_FAIL_CONTINUES_, cr_file_match_str, !=, __VA_ARGS__))
+# undef cr_assert_file_contents_eq
+# define cr_assert_file_contents_eq(...) CR_EXPAND(cr_assert_redir_f_op_va_(CR_FAIL_ABORT_,     cr_file_match_file, ==, __VA_ARGS__))
+# undef cr_expect_file_contents_eq
+# define cr_expect_file_contents_eq(...) CR_EXPAND(cr_assert_redir_f_op_va_(CR_FAIL_CONTINUES_, cr_file_match_file, ==, __VA_ARGS__))
+# undef cr_assert_file_contents_neq
+# define cr_assert_file_contents_neq(...) CR_EXPAND(cr_assert_redir_f_op_va_(CR_FAIL_ABORT_,     cr_file_match_file, !=, __VA_ARGS__))
+# undef cr_expect_file_contents_neq
+# define cr_expect_file_contents_neq(...) CR_EXPAND(cr_assert_redir_f_op_va_(CR_FAIL_CONTINUES_, cr_file_match_file, !=, __VA_ARGS__))
+# undef cr_assert_stdout_eq_str
+# define cr_assert_stdout_eq_str(...) CR_EXPAND(cr_assert_redir_op_va_(CR_FAIL_ABORT_,     cr_file_match_str, ==, cr_get_redirected_stdout(), __VA_ARGS__))
+# undef cr_expect_stdout_eq_str
+# define cr_expect_stdout_eq_str(...) CR_EXPAND(cr_assert_redir_op_va_(CR_FAIL_CONTINUES_, cr_file_match_str, ==, cr_get_redirected_stdout(), __VA_ARGS__))
+# undef cr_assert_stdout_neq_str
+# define cr_assert_stdout_neq_str(...) CR_EXPAND(cr_assert_redir_op_va_(CR_FAIL_ABORT_,     cr_file_match_str, !=, cr_get_redirected_stdout(), __VA_ARGS__))
+# undef cr_expect_stdout_neq_str
+# define cr_expect_stdout_neq_str(...) CR_EXPAND(cr_assert_redir_op_va_(CR_FAIL_CONTINUES_, cr_file_match_str, !=, cr_get_redirected_stdout(), __VA_ARGS__))
+# undef cr_assert_stderr_eq_str
+# define cr_assert_stderr_eq_str(...) CR_EXPAND(cr_assert_redir_op_va_(CR_FAIL_ABORT_,     cr_file_match_str, ==, cr_get_redirected_stderr(), __VA_ARGS__))
+# undef cr_expect_stderr_eq_str
+# define cr_expect_stderr_eq_str(...) CR_EXPAND(cr_assert_redir_op_va_(CR_FAIL_CONTINUES_, cr_file_match_str, ==, cr_get_redirected_stderr(), __VA_ARGS__))
+# undef cr_assert_stderr_neq_str
+# define cr_assert_stderr_neq_str(...) CR_EXPAND(cr_assert_redir_op_va_(CR_FAIL_ABORT_,     cr_file_match_str, !=, cr_get_redirected_stderr(), __VA_ARGS__))
+# undef cr_expect_stderr_neq_str
+# define cr_expect_stderr_neq_str(...) CR_EXPAND(cr_assert_redir_op_va_(CR_FAIL_CONTINUES_, cr_file_match_str, !=, cr_get_redirected_stderr(), __VA_ARGS__))
+# undef cr_assert_stdout_eq
+# define cr_assert_stdout_eq(...) CR_EXPAND(cr_assert_redir_f_op_va_(CR_FAIL_ABORT_,     cr_file_match_file, ==, cr_get_redirected_stdout(), __VA_ARGS__))
+# undef cr_expect_stdout_eq
+# define cr_expect_stdout_eq(...) CR_EXPAND(cr_assert_redir_f_op_va_(CR_FAIL_CONTINUES_, cr_file_match_file, ==, cr_get_redirected_stdout(), __VA_ARGS__))
+# undef cr_assert_stdout_neq
+# define cr_assert_stdout_neq(...) CR_EXPAND(cr_assert_redir_f_op_va_(CR_FAIL_ABORT_,     cr_file_match_file, !=, cr_get_redirected_stdout(), __VA_ARGS__))
+# undef cr_expect_stdout_neq
+# define cr_expect_stdout_neq(...) CR_EXPAND(cr_assert_redir_f_op_va_(CR_FAIL_CONTINUES_, cr_file_match_file, !=, cr_get_redirected_stdout(), __VA_ARGS__))
+# undef cr_assert_stderr_eq
+# define cr_assert_stderr_eq(...) CR_EXPAND(cr_assert_redir_f_op_va_(CR_FAIL_ABORT_,     cr_file_match_file, ==, cr_get_redirected_stderr(), __VA_ARGS__))
+# undef cr_expect_stderr_eq
+# define cr_expect_stderr_eq(...) CR_EXPAND(cr_assert_redir_f_op_va_(CR_FAIL_CONTINUES_, cr_file_match_file, ==, cr_get_redirected_stderr(), __VA_ARGS__))
+# undef cr_assert_stderr_neq
+# define cr_assert_stderr_neq(...) CR_EXPAND(cr_assert_redir_f_op_va_(CR_FAIL_ABORT_,     cr_file_match_file, !=, cr_get_redirected_stderr(), __VA_ARGS__))
+# undef cr_expect_stderr_neq
+# define cr_expect_stderr_neq(...) CR_EXPAND(cr_assert_redir_f_op_va_(CR_FAIL_CONTINUES_, cr_file_match_file, !=, cr_get_redirected_stderr(), __VA_ARGS__))
 
 #endif /* !CRITERION_INTERNAL_REDIRECT_H_ */

--- a/include/criterion/internal/test.h
+++ b/include/criterion/internal/test.h
@@ -181,5 +181,9 @@ static const char *const cr_msg_test_fini_other_exception = "Caught some unexpec
     struct criterion_suite *CR_SUITE_IDENTIFIER_(Name, ptr)                    \
 	    = &CR_SUITE_IDENTIFIER_(Name, meta) CR_SECTION_SUFFIX_
 
+# undef Test
+# define Test(...) CR_EXPAND(CR_TEST_BASE(__VA_ARGS__, .sentinel_ = 0))
+# undef TestSuite
+# define TestSuite(...) CR_EXPAND(CR_SUITE_BASE(__VA_ARGS__, .sentinel_ = 0))
 
 #endif /* !CRITERION_INTERNAL_TEST_H_ */

--- a/include/criterion/internal/theories.h
+++ b/include/criterion/internal/theories.h
@@ -91,4 +91,12 @@ CR_END_C_API
     }                                                                          \
     void CR_EXPAND(CR_VAARG_ID(theory, __VA_ARGS__,))Args
 
+# define cr_assume_op_(Op, Actual, Expected) cr_assume((Actual) Op (Expected))
+
+# define cr_assume_str_op_(Op, Actual, Expected) \
+    cr_assume(strcmp((Actual), (Expected)) Op 0)
+
+# undef Theory
+# define Theory(Args, ...) CR_EXPAND(CR_THEORY_BASE(Args, __VA_ARGS__))
+
 #endif /* !CRITERION_INTERNAL_THEORIES_H_ */

--- a/include/criterion/parameterized.h
+++ b/include/criterion/parameterized.h
@@ -30,7 +30,11 @@
 
 # include "alloc.h"
 # include "assert.h"
-# include "internal/parameterized.h"
+
+/**
+ * @defgroup ParameterizedBase Parameterized test & generator macros
+ * @{
+ */
 
 /**
  *  ParameterizedTest(Type *param, Suite, Name, [Options...]) { Function Body }
@@ -43,29 +47,29 @@
  *  @param Type    The type of the parameter.
  *  @param Suite   The name of the test suite containing this test.
  *  @param Name    The name of the test.
- *  @param Options An optional sequence of designated initializer key/value
+ *  @param ...     An optional sequence of designated initializer key/value
  *    pairs as described in the `criterion_test_extra_data` structure
  *    (see criterion/types.h).
- *    Example: .exit_code = 1
+ *    Example: `.exit_code = 1`
  */
-# define ParameterizedTest(...) CR_EXPAND(CR_PARAM_TEST_BASE(__VA_ARGS__, .sentinel_ = 0))
+# define ParameterizedTest(Type, Suite, Name, ...) <internal>
 
 /**
- *  ParameterizedTestParameters(Suite, Test) { Function Body }
- *
- *  Defines the parameter generator for the associated parameterized test.
+ *  Defines the parameter generator prototype for the associated parameterized
+ *  test.
  *
  *  @param Suite   The name of the test suite containing the test.
  *  @param Test    The name of the test.
  *  @returns A constructed instance of criterion::parameters, or the result of
  *    the cr_make_param_array macro.
  */
-# define ParameterizedTestParameters(Suite, Name) CR_PARAM_TEST_PARAMS(Suite, Name)
+# define ParameterizedTestParameters(Suite, Name) <internal>
 
 /**
- *  cr_make_param_array(Type, Array, Len, [Cleanup]);
- *
  *  Constructs a parameter list used as a return value for a parameter generator.
+ *
+ *  This is only recommended for C sources. For C++, use `criterion::parameters`
+ *  or `criterion_test_params`.
  *
  *  @param Type     The type of the array subscript.
  *  @param Array    The array of parameters.
@@ -73,15 +77,29 @@
  *  @param Cleanup  The optional cleanup function for the array.
  *  @returns The parameter list.
  */
-# define cr_make_param_array(...) CR_EXPAND(cr_make_param_array_(__VA_ARGS__))
+# define cr_make_param_array(Type, Array, Len, Cleanup) <internal>
 
 # ifdef __cplusplus
 #  include <vector>
 
 namespace criterion {
+
+    /**
+     *  Represents a C++ dynamic parameter list for a parameter generator.
+     *
+     *  @param Type     The type of the array subscript.
+     *  @param Array    The array of parameters.
+     *  @param Len      The length of the array.
+     *  @param Cleanup  The optional cleanup function for the array.
+     *  @returns The parameter list.
+     */
     template <typename T>
     using parameters = std::vector<T, criterion::allocator<T>>;
 }
 # endif
+
+/** @} */
+
+# include "internal/parameterized.h"
 
 #endif /* !CRITERION_PARAMETERIZED_H_ */

--- a/include/criterion/parameterized.h
+++ b/include/criterion/parameterized.h
@@ -79,6 +79,8 @@
  */
 # define cr_make_param_array(Type, Array, Len, Cleanup) <internal>
 
+/** @} */
+
 # ifdef __cplusplus
 #  include <vector>
 
@@ -87,18 +89,14 @@ namespace criterion {
     /**
      *  Represents a C++ dynamic parameter list for a parameter generator.
      *
-     *  @param Type     The type of the array subscript.
-     *  @param Array    The array of parameters.
-     *  @param Len      The length of the array.
-     *  @param Cleanup  The optional cleanup function for the array.
-     *  @returns The parameter list.
+     *  @ingroup ParameterizedBase
+     *
+     *  @param T The type of the parameter.
      */
     template <typename T>
     using parameters = std::vector<T, criterion::allocator<T>>;
 }
 # endif
-
-/** @} */
 
 # include "internal/parameterized.h"
 

--- a/include/criterion/redirect.h
+++ b/include/criterion/redirect.h
@@ -104,7 +104,6 @@ CR_API CR_STDN FILE *cr_mock_file_size(size_t max_size);
 
 CR_END_C_API
 
-
 /**
  * @defgroup FileAsserts File content assertions
  * @{
@@ -113,9 +112,6 @@ CR_END_C_API
 /**
  * Passes if the contents of \c File are equal to the string \c ExpectedContents
  *
- * Call: \c cr_assert_file_contents_eq_str(File, ExpectedContents,
- * [FormatString, [Args...]])
- *
  * Passes if the contents of \c File are equal to the string
  * \c ExpectedContents.
  * Otherwise the test is marked as failure and the execution of the function
@@ -125,19 +121,15 @@ CR_END_C_API
  *
  * @param[in] File Pointer to a FILE object that specifies an input stream
  * @param[in] ExpectedContents C string with the ExpectedContents
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_assert_file_contents_eq_str(...) CR_EXPAND(cr_assert_redir_op_va_(CR_FAIL_ABORT_,     cr_file_match_str, ==, __VA_ARGS__))
+# define cr_assert_file_contents_eq_str(File, ExpectedContents, FormatString, ...) <internal>
 
 /**
  * Passes if the contents of \c File are equal to the string \c ExpectedContents
  *
- * Call: \c cr_expect_file_contents_eq_str(File, ExpectedContents,
- * [FormatString, [Args...]])
- *
  * Passes if the contents of \c File are equal to the string
  * \c ExpectedContents.
  * Otherwise the test is marked as failure but the execution will continue.
@@ -146,19 +138,15 @@ CR_END_C_API
  *
  * @param[in] File Pointer to a FILE object that specifies an input stream
  * @param[in] ExpectedContents C string with the ExpectedContents
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_expect_file_contents_eq_str(...) CR_EXPAND(cr_assert_redir_op_va_(CR_FAIL_CONTINUES_, cr_file_match_str, ==, __VA_ARGS__))
+# define cr_expect_file_contents_eq_str(File, ExpectedContents, FormatString, ...) <internal>
 
 /**
  * Passes if the contents of \c File are not equal to the string
  * \c UnexpectedContents
- *
- * Call: \c cr_assert_file_contents_neq_str(File, UnexpectedContents,
- * [FormatString, [Args...]])
  *
  * Passes if the contents of \c File are not equal to the string
  * \c UnexpectedContents.
@@ -169,18 +157,15 @@ CR_END_C_API
  *
  * @param[in] File Pointer to a FILE object that specifies an input stream
  * @param[in] UnexpectedContents C string with the UnexpectedContents
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-# define cr_assert_file_contents_neq_str(...) CR_EXPAND(cr_assert_redir_op_va_(CR_FAIL_ABORT_,     cr_file_match_str, !=, __VA_ARGS__))
+# define cr_assert_file_contents_neq_str(File, UnexpectedContents, FormatString, ...) <internal>
 
 /**
  * Passes if the contents of \c File are not equal to the string
  * \c UnexpectedContents
- *
- * Call: \c cr_expect_file_contents_neq_str(File, UnexpectedContents,
- * [FormatString, [Args...]])
  *
  * Passes if the contents of \c File are not equal to the string
  * \c UnexpectedContents.
@@ -190,18 +175,14 @@ CR_END_C_API
  *
  * @param[in] File Pointer to a FILE object that specifies an input stream
  * @param[in] UnexpectedContents C string with the UnexpectedContents
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_expect_file_contents_neq_str(...) CR_EXPAND(cr_assert_redir_op_va_(CR_FAIL_CONTINUES_, cr_file_match_str, !=, __VA_ARGS__))
+# define cr_expect_file_contents_neq_str(File, UnexpectedContents, FormatString, ...) <internal>
 
 /**
  * Passes if the contents of \c File are equal to the contents of \c RefFile
- *
- * Call: \c cr_assert_file_contents_eq(File, RefFile, [FormatString,
- * [Args...]])
  *
  * Passes if the contents of \c File are equal to the contents of \c RefFile.
  * Otherwise the test is marked as failure and the execution of the function
@@ -211,17 +192,14 @@ CR_END_C_API
  *
  * @param[in] File Pointer to a FILE object that specifies an input stream
  * @param[in] RefFile Pointer to a FILE object that specifies an input stream
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-# define cr_assert_file_contents_eq(...) CR_EXPAND(cr_assert_redir_f_op_va_(CR_FAIL_ABORT_,     cr_file_match_file, ==, __VA_ARGS__))
+# define cr_assert_file_contents_eq(File, RefFile, FormatString, ...) <internal>
 
 /**
  * Passes if the contents of \c File are equal to the contents of \c RefFile
- *
- * Call: \c cr_expect_file_contents_eq(File, RefFile, [FormatString,
- * [Args...]])
  *
  * Passes if the contents of \c File are equal to the contents of \c RefFile.
  * Otherwise the test is marked as failure but the execution will continue.
@@ -230,19 +208,15 @@ CR_END_C_API
  *
  * @param[in] File Pointer to a FILE object that specifies an input stream
  * @param[in] RefFile Pointer to a FILE object that specifies an input stream
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_expect_file_contents_eq(...) CR_EXPAND(cr_assert_redir_f_op_va_(CR_FAIL_CONTINUES_, cr_file_match_file, ==, __VA_ARGS__))
+# define cr_expect_file_contents_eq(File, RefFile, FormatString, ...) <internal>
 
 /**
  * Passes if the contents of \c File are not equal to the contents of
  * \c RefFile
- *
- * Call: \c cr_assert_file_contents_neq(File, RefFile, [FormatString,
- * [Args...]])
  *
  * Passes if the contents of \c File are not equal to the contents of
  * \c RefFile.
@@ -253,18 +227,15 @@ CR_END_C_API
  *
  * @param[in] File Pointer to a FILE object that specifies an input stream
  * @param[in] RefFile Pointer to a FILE object that specifies an input stream
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-# define cr_assert_file_contents_neq(...) CR_EXPAND(cr_assert_redir_f_op_va_(CR_FAIL_ABORT_,     cr_file_match_file, !=, __VA_ARGS__))
+# define cr_assert_file_contents_neq(File, RefFile, FormatString, ...) <internal>
 
 /**
  * Passes if the contents of \c File are not equal to the contents of
  * \c RefFile
- *
- * Call: \c cr_expect_file_contents_neq(File, RefFile, [FormatString,
- * [Args...]])
  *
  * Passes if the contents of \c File are not equal to the contents of
  * \c RefFile.
@@ -274,12 +245,11 @@ CR_END_C_API
  *
  * @param[in] File Pointer to a FILE object that specifies an input stream
  * @param[in] RefFile Pointer to a FILE object that specifies an input stream
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_expect_file_contents_neq(...) CR_EXPAND(cr_assert_redir_f_op_va_(CR_FAIL_CONTINUES_, cr_file_match_file, !=, __VA_ARGS__))
+# define cr_expect_file_contents_neq(File, RefFile, FormatString, ...) <internal>
 
 /**@}*/
 
@@ -292,9 +262,6 @@ CR_END_C_API
  * Passes if the contents of \c stdout are equal to the contents of the string
  * \c ExpectedContents
  *
- * Call: \c cr_assert_stdout_eq_str(ExpectedContents, [FormatString,
- * [Args...]])
- *
  * Passes if the contents of \c stdout are equal to the contents of the string
  * \c ExpectedContents.
  * Otherwise the test is marked as failure and the execution of the function
@@ -303,18 +270,15 @@ CR_END_C_API
  * The optional string is printed on failure.
  *
  * @param[in] ExpectedContents C string with the ExpectedContents
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-# define cr_assert_stdout_eq_str(...) CR_EXPAND(cr_assert_redir_op_va_(CR_FAIL_ABORT_,     cr_file_match_str, ==, cr_get_redirected_stdout(), __VA_ARGS__))
+# define cr_assert_stdout_eq_str(ExpectedContents, FormatString, ...) <internal>
 
 /**
  * Passes if the contents of \c stdout are equal to the contents of the string
  * \c ExpectedContents
- *
- * Call: \c cr_expect_stdout_eq_str(ExpectedContents, [FormatString,
- * [Args...]])
  *
  * Passes if the contents of \c stdout are equal to the contents of the string
  * \c ExpectedContents.
@@ -323,19 +287,15 @@ CR_END_C_API
  * The optional string is printed on failure.
  *
  * @param[in] ExpectedContents C string with the ExpectedContents
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_expect_stdout_eq_str(...) CR_EXPAND(cr_assert_redir_op_va_(CR_FAIL_CONTINUES_, cr_file_match_str, ==, cr_get_redirected_stdout(), __VA_ARGS__))
+# define cr_expect_stdout_eq_str(ExpectedContents, FormatString, ...) <internal>
 
 /**
  * Passes if the contents of \c stdout are not equal to the contents of the
  * string \c UnexpectedContents
- *
- * Call: \c cr_assert_stdout_neq_str(UnexpectedContents, [FormatString,
- * [Args...]])
  *
  * Passes if the contents of \c stdout are not equal to the contents of the
  * string \c UnexpectedContents.
@@ -345,18 +305,15 @@ CR_END_C_API
  * The optional string is printed on failure.
  *
  * @param[in] UnexpectedContents C string with the UnexpectedContents
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-# define cr_assert_stdout_neq_str(...) CR_EXPAND(cr_assert_redir_op_va_(CR_FAIL_ABORT_,     cr_file_match_str, !=, cr_get_redirected_stdout(), __VA_ARGS__))
+# define cr_assert_stdout_neq_str(UnexpectedContents, FormatString, ...) <internal>
 
 /**
  * Passes if the contents of \c stdout are not equal to the contents of the
  * string \c UnexpectedContents
- *
- * Call: \c cr_expect_stdout_neq_str(UnexpectedContents, [FormatString,
- * [Args...]])
  *
  * Passes if the contents of \c stdout are not equal to the contents of the
  * string \c UnexpectedContents.
@@ -365,19 +322,15 @@ CR_END_C_API
  * The optional string is printed on failure.
  *
  * @param[in] UnexpectedContents C string with the UnexpectedContents
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_expect_stdout_neq_str(...) CR_EXPAND(cr_assert_redir_op_va_(CR_FAIL_CONTINUES_, cr_file_match_str, !=, cr_get_redirected_stdout(), __VA_ARGS__))
+# define cr_expect_stdout_neq_str(UnexpectedContents, FormatString, ...) <internal>
 
 /**
  * Passes if the contents of \c stderr are equal to the contents of the string
  * \c ExpectedContents
- *
- * Call: \c cr_assert_stderr_eq_str(ExpectedContents, [FormatString,
- * [Args...]])
  *
  * Passes if the contents of \c stderr are equal to the contents of the string
  * \c ExpectedContents.
@@ -387,18 +340,15 @@ CR_END_C_API
  * The optional string is printed on failure.
  *
  * @param[in] ExpectedContents C string with the ExpectedContents
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-# define cr_assert_stderr_eq_str(...) CR_EXPAND(cr_assert_redir_op_va_(CR_FAIL_ABORT_,     cr_file_match_str, ==, cr_get_redirected_stderr(), __VA_ARGS__))
+# define cr_assert_stderr_eq_str(ExpectedContents, FormatString, ...) <internal>
 
 /**
  * Passes if the contents of \c stderr are equal to the contents of the string
  * \c ExpectedContents
- *
- * Call: \c cr_expect_stderr_eq_str(ExpectedContents, [FormatString,
- * [Args...]])
  *
  * Passes if the contents of \c stderr are equal to the contents of the string
  * \c ExpectedContents.
@@ -407,19 +357,15 @@ CR_END_C_API
  * The optional string is printed on failure.
  *
  * @param[in] ExpectedContents C string with the ExpectedContents
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_expect_stderr_eq_str(...) CR_EXPAND(cr_assert_redir_op_va_(CR_FAIL_CONTINUES_, cr_file_match_str, ==, cr_get_redirected_stderr(), __VA_ARGS__))
+# define cr_expect_stderr_eq_str(ExpectedContents, FormatString, ...) <internal>
 
 /**
  * Passes if the contents of \c stderr are not equal to the contents of the
  * string \c UnexpectedContents
- *
- * Call: \c cr_assert_sterr_neq_str(UnexpectedContents, [FormatString,
- * [Args...]])
  *
  * Passes if the contents of \c stderr are not equal to the contents of the
  * string \c UnexpectedContents.
@@ -429,18 +375,15 @@ CR_END_C_API
  * The optional string is printed on failure.
  *
  * @param[in] UnexpectedContents C string with the UnexpectedContents
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-# define cr_assert_stderr_neq_str(...) CR_EXPAND(cr_assert_redir_op_va_(CR_FAIL_ABORT_,     cr_file_match_str, !=, cr_get_redirected_stderr(), __VA_ARGS__))
+# define cr_assert_stderr_neq_str(UnexpectedContents, FormatString, ...) <internal>
 
 /**
  * Passes if the contents of \c stderr are not equal to the contents of the
  * string \c UnexpectedContents
- *
- * Call: \c cr_expect_sterr_neq_str(UnexpectedContents, [FormatString,
- * [Args...]])
  *
  * Passes if the contents of \c stderr are not equal to the contents of the
  * string \c UnexpectedContents.
@@ -449,18 +392,14 @@ CR_END_C_API
  * The optional string is printed on failure.
  *
  * @param[in] UnexpectedContents C string with the UnexpectedContents
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_expect_stderr_neq_str(...) CR_EXPAND(cr_assert_redir_op_va_(CR_FAIL_CONTINUES_, cr_file_match_str, !=, cr_get_redirected_stderr(), __VA_ARGS__))
+# define cr_expect_stderr_neq_str(UnexpectedContents, FormatString, ...) <internal>
 
 /**
  * Passes if the contents of \c stdout are equal to the contents of \c RefFile
- *
- * Call: \c cr_assert_stdout_eq(RefFile, [FormatString,
- * [Args...]])
  *
  * Passes if the contents of \c stdout are equal to the contents of \c RefFile.
  * Otherwise the test is marked as failure and the execution of the function
@@ -469,17 +408,14 @@ CR_END_C_API
  * The optional string is printed on failure.
  *
  * @param[in] RefFile Pointer to a FILE object that specifies an input stream
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-# define cr_assert_stdout_eq(...) CR_EXPAND(cr_assert_redir_f_op_va_(CR_FAIL_ABORT_,     cr_file_match_file, ==, cr_get_redirected_stdout(), __VA_ARGS__))
+# define cr_assert_stdout_eq(RefFile, FormatString, ...) <internal>
 
 /**
  * Passes if the contents of \c stdout are equal to the contents of \c RefFile
- *
- * Call: \c cr_expect_stdout_eq(RefFile, [FormatString,
- * [Args...]])
  *
  * Passes if the contents of \c stdout are equal to the contents of \c RefFile.
  * Otherwise the test is marked as failure but the execution will continue.
@@ -487,18 +423,15 @@ CR_END_C_API
  * The optional string is printed on failure.
  *
  * @param[in] RefFile Pointer to a FILE object that specifies an input stream
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_expect_stdout_eq(...) CR_EXPAND(cr_assert_redir_f_op_va_(CR_FAIL_CONTINUES_, cr_file_match_file, ==, cr_get_redirected_stdout(), __VA_ARGS__))
+# define cr_expect_stdout_eq(RefFile, FormatString, ...) <internal>
 
 /**
  * Passes if the contents of \c stdout are not equal to the contents of \c
  * RefFile
- *
- * Call: \c cr_assert_stout_neq(RefFile, [FormatString, [Args...]])
  *
  * Passes if the contents of \c stdout are not equal to the contents of \c
  * RefFile.
@@ -508,17 +441,15 @@ CR_END_C_API
  * The optional string is printed on failure.
  *
  * @param[in] RefFile Pointer to a FILE object that specifies an input stream
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-# define cr_assert_stdout_neq(...) CR_EXPAND(cr_assert_redir_f_op_va_(CR_FAIL_ABORT_,     cr_file_match_file, !=, cr_get_redirected_stdout(), __VA_ARGS__))
+# define cr_assert_stdout_neq(RefFile, FormatString, ...) <internal>
 
 /**
  * Passes if the contents of \c stdout are not equal to the contents of \c
  * RefFile
- *
- * Call: \c cr_expect_stout_neq(RefFile, [FormatString, [Args...]])
  *
  * Passes if the contents of \c stdout are not equal to the contents of \c
  * RefFile.
@@ -527,17 +458,14 @@ CR_END_C_API
  * The optional string is printed on failure.
  *
  * @param[in] RefFile Pointer to a FILE object that specifies an input stream
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_expect_stdout_neq(...) CR_EXPAND(cr_assert_redir_f_op_va_(CR_FAIL_CONTINUES_, cr_file_match_file, !=, cr_get_redirected_stdout(), __VA_ARGS__))
+# define cr_expect_stdout_neq(RefFile, FormatString, ...) <internal>
 
 /**
  * Passes if the contents of \c stderr are equal to the contents of \c RefFile
- *
- * Call: \c cr_assert_stderr_eq(RefFile, [FormatString, [Args...]])
  *
  * Passes if the contents of \c stderr are equal to the contents of \c RefFile.
  * Otherwise the test is marked as failure and the execution of the function
@@ -546,16 +474,14 @@ CR_END_C_API
  * The optional string is printed on failure.
  *
  * @param[in] RefFile Pointer to a FILE object that specifies an input stream
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-# define cr_assert_stderr_eq(...) CR_EXPAND(cr_assert_redir_f_op_va_(CR_FAIL_ABORT_,     cr_file_match_file, ==, cr_get_redirected_stderr(), __VA_ARGS__))
+# define cr_assert_stderr_eq(RefFile, FormatString, ...) <internal>
 
 /**
  * Passes if the contents of \c stderr are equal to the contents of \c RefFile
- *
- * Call: \c cr_expect_stderr_eq(RefFile, [FormatString, [Args...]])
  *
  * Passes if the contents of \c stderr are equal to the contents of \c RefFile.
  * Otherwise the test is marked as failure but the execution will continue.
@@ -563,53 +489,46 @@ CR_END_C_API
  * The optional string is printed on failure.
  *
  * @param[in] RefFile Pointer to a FILE object that specifies an input stream
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-
-# define cr_expect_stderr_eq(...) CR_EXPAND(cr_assert_redir_f_op_va_(CR_FAIL_CONTINUES_, cr_file_match_file, ==, cr_get_redirected_stderr(), __VA_ARGS__))
+# define cr_expect_stderr_eq(RefFile, FormatString, ...) <internal>
 
 /**
  * Passes if the contents of \c stderr are not equal to the contents of \c
  * RefFile
- *
- * Call: \c cr_expect_sterr_neq(RefFile, [FormatString, [Args...]])
  *
  * Passes if the contents of \c stderr are not equal to the contents of \c
  * RefFile.
  * Otherwise the test is marked as failure and the execution of the function
  * is aborted.
  *
- *
  * The optional string is printed on failure.
  *
  * @param[in] RefFile Pointer to a FILE object that specifies an input stream
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-# define cr_assert_stderr_neq(...) CR_EXPAND(cr_assert_redir_f_op_va_(CR_FAIL_ABORT_,     cr_file_match_file, !=, cr_get_redirected_stderr(), __VA_ARGS__))
+# define cr_assert_stderr_neq(RefFile, FormatString, ...) <internal>
 
 /**
  * Passes if the contents of \c stderr are not equal to the contents of \c
  * RefFile
  *
- * Call: \c cr_expect_sterr_neq(RefFile, [FormatString, [Args...]])
- *
  * Passes if the contents of \c stderr are not equal to the contents of \c
  * RefFile.
  * Otherwise the test is marked as failure but the execution will continue.
  *
- *
  * The optional string is printed on failure.
  *
  * @param[in] RefFile Pointer to a FILE object that specifies an input stream
- * @param[in] FormatString printf like format string
- * @param[in] Args Additional arguments depending on FormatString
+ * @param[in] FormatString (optional) printf-like format string
+ * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-# define cr_expect_stderr_neq(...) CR_EXPAND(cr_assert_redir_f_op_va_(CR_FAIL_CONTINUES_, cr_file_match_file, !=, cr_get_redirected_stderr(), __VA_ARGS__))
+# define cr_expect_stderr_neq(RefFile, FormatString, ...) <internal>
 
 /**@}*/
 

--- a/include/criterion/redirect.h
+++ b/include/criterion/redirect.h
@@ -29,7 +29,6 @@
 # define CRITERION_REDIRECT_H_
 
 # include "internal/common.h"
-# include "internal/redirect.h"
 
 # ifdef __cplusplus
 #  include <cstdio>
@@ -564,5 +563,7 @@ namespace criterion {
 #  endif
 }
 # endif
+
+# include "internal/redirect.h"
 
 #endif /* !CRITERION_REDIRECT_H_ */

--- a/include/criterion/theories.h
+++ b/include/criterion/theories.h
@@ -29,7 +29,6 @@
 # define CRITERION_THEORIES_H_
 
 # include "criterion.h"
-# include "internal/theories.h"
 
 CR_BEGIN_C_API
 
@@ -42,50 +41,59 @@ CR_API void cr_theory_abort(void);
 CR_END_C_API
 
 /**
- * @defgroup TheoryDatapoints Theory and datapoint macros
+ * @defgroup TheoryBase Theory and datapoint macros
  * @{
  */
 
 /**
- *  Theory((Params...), Suite, Name, [Options...]) { Function Body }
- *
  *  Defines a new theory test.
  *
  *  The parameters are selected from a cartesian product defined by a
  *  TheoryDataPoints macro.
  *
+ *  Example:
+ *  @code{.c}
+ *  Theory((int arg0, double arg1), suite, test) {
+ *      // function body
+ *  };
+ *  @endcode
+ *
  *  @param Params  A list of function parameters.
  *  @param Suite   The name of the test suite containing this test.
  *  @param Name    The name of the test.
- *  @param Options An optional sequence of designated initializer key/value
+ *  @param ...     An optional sequence of designated initializer key/value
  *    pairs as described in the `criterion_test_extra_data` structure
  *    (see criterion/types.h).
  *    Example: .exit_code = 1
  */
-# define Theory(Args, ...) CR_EXPAND(CR_THEORY_BASE(Args, __VA_ARGS__))
+# define Theory(Params, Suite, Name, ...) <internal>
 
 /**
- *  TheoryDataPoints(Suite, Name) = { Datapoints... };
- *
  *  Defines an array of data points.
  *
  *  The types of the specified data points *must* match the types of the
  *  associated theory.
  *
- *  Each entry in the array must be the result of the DataPoints macro.
+ *  Each entry in the array must be the result of the `DataPoints` macro.
+ *
+ *  Example:
+ *  @code{.c}
+ *  TheoryDataPoints(suite, test) = {
+ *      DataPoints(int, 1, 2, 3),               // first theory parameter
+ *      DataPoints(double, 4.2, 0, -INFINITY),  // second theory parameter
+ *  };
+ *  @endcode
  *
  *  @param Suite   The name of the test suite containing this test.
  *  @param Name    The name of the test.
  */
-# define TheoryDataPoints(Category, Name) CR_TH_INTERNAL_TDPS(Category, Name)
+# define TheoryDataPoints(Suite, Name) CR_TH_INTERNAL_TDPS(Suite, Name)
 
 /**
- *  DataPoints(Type, Values...)
- *
  *  Defines a new set of data points.
  *
- *  @param Type    The type of each data point in the set.
- *  @param Values  The data points in the set.
+ *  @param Type The type of each data point in the set.
+ *  @param ...  The data points in the set.
  */
 # define DataPoints(Type, ...) CR_EXPAND(CR_TH_INTERNAL_DP(Type, __VA_ARGS__))
 
@@ -123,8 +131,6 @@ CR_END_C_API
  *
  *****************************************************************************/
 # define cr_assume_not(Condition) cr_assume(!(Condition))
-
-# define cr_assume_op_(Op, Actual, Expected) cr_assume((Actual) Op (Expected))
 
 /**
  * Assumes `Actual` is equal to `Expected`
@@ -264,9 +270,6 @@ CR_END_C_API
     cr_assume((Expected) - (Actual) > (Epsilon)         \
            || (Actual) - (Expected) > (Epsilon))
 
-# define cr_assume_str_op_(Op, Actual, Expected) \
-    cr_assume(strcmp((Actual), (Expected)) Op 0)
-
 /**
  * Assumes `Actual` is lexicographically equal to `Expected`
  *
@@ -375,6 +378,7 @@ CR_END_C_API
 # define cr_assume_arr_neq(Actual, Unexpected, Size) cr_assume(memcmp((Actual), (Unexpected), (Size)))
 
 /**@}*/
+
 // Deprecated
 
 # ifndef CRITERION_NO_COMPAT
@@ -388,5 +392,7 @@ CR_END_C_API
 #  define cr_assume_arrays_eq(...) CRITERION_ASSERT_DEPRECATED_B(cr_assume_arrays_eq, cr_assume_arr_eq) cr_assume_arr_eq(__VA_ARGS__)
 #  define cr_assume_arrays_neq(...) CRITERION_ASSERT_DEPRECATED_B(cr_assume_arrays_neq, cr_assume_arr_neq) cr_assume_arr_neq(__VA_ARGS__)
 # endif
+
+# include "internal/theories.h"
 
 #endif /* !CRITERION_THEORIES_H_ */

--- a/include/criterion/theories.h
+++ b/include/criterion/theories.h
@@ -359,6 +359,7 @@ CR_END_C_API
  *
  * @param[in] Actual Array to test
  * @param[in] Expected Expected array
+ * @param[in] Size The size of both arrays
  *
  *****************************************************************************/
 # define cr_assume_arr_eq(Actual, Expected, Size)  cr_assume(!memcmp((Actual), (Expected), (Size)))
@@ -373,6 +374,7 @@ CR_END_C_API
  *
  * @param[in] Actual Array to test
  * @param[in] Unexpected Unexpected array
+ * @param[in] Size The size of both arrays
  *
  *****************************************************************************/
 # define cr_assume_arr_neq(Actual, Unexpected, Size) cr_assume(memcmp((Actual), (Unexpected), (Size)))

--- a/include/criterion/types.h
+++ b/include/criterion/types.h
@@ -89,14 +89,78 @@ struct criterion_test_extra_data {
     // Enf of private API
     /// @endcond
 
-    void (*init)(void);         //!< The setup test fixture
-    void (*fini)(void);         //!< The setup test fixture
-    int signal;                 //!< The expected signal raised by the test (or 0 if none)
-    int exit_code;              //!< The expected exit code returned by the test
-    bool disabled;              //!< Whether the test is disabled or not
-    const char *description;    //!< The description of a test
-    double timeout;             //!< A timeout for the test in seconds
-    void *data;                 //!< Extra user data
+    /**
+     * The setup test fixture.
+     *
+     * This function, if provided, will be executed during the initialization
+     * of the test.
+     */
+    void (*init)(void);
+
+    /**
+     * The teardown test fixture.
+     *
+     * This function, if provided, will be executed during the finalization
+     * of the test.
+     */
+    void (*fini)(void);
+
+    /**
+     * The expected signal to be raised by the test.
+     *
+     * If the test does not raise the specified signal, then the test is
+     * marked as failed.
+     *
+     * A value of 0 means that is it not expected for the test to raise any
+     * signal.
+     */
+    int signal;
+
+    /**
+     * The expected exit status to be returned by the test.
+     *
+     * By default, criterion exits the test process with a value of 0. If it
+     * is expected for the test to exit with a non-zero status, this option
+     * can be used.
+     */
+    int exit_code;
+
+    /**
+     * If `true`, disables the test.
+     *
+     * The test will still appear in the test list, but will be marked as
+     * skipped and will not be executed.
+     */
+    bool disabled;
+
+    /**
+     * The long description of a test.
+     *
+     * If a description is provided, it will be printed in test reports, and
+     * logged if the runner runs in verbose mode.
+     */
+    const char *description;
+
+    /**
+     * The timeout for the test, in seconds.
+     *
+     * If the realtime execution of a test takes longer than the specified
+     * value, then the test is immediately aborted and reported as timing out.
+     *
+     * A value of `0` is equivalent to `+INFINITY` and means that the test
+     * does not timeout.
+     *
+     * It is unspecified behaviour for the value of `timeout` to be negative
+     * or `NaN`.
+     */
+    double timeout;
+
+    /**
+     * Extra user data.
+     *
+     * This field is currently unused.
+     */
+    void *data;
 };
 
 /**


### PR DESCRIPTION
Thanks to the recent work of @a1lu, we got some proper doxygen generation on the repository.

However, this effectively split the documentation in half, with sphinx on one hand and doxygen on the other.

This PR aims to harmonize both documentations by integrating doxygen comments into the sphinx doc -- the current result can be browsed [here](http://criterion.readthedocs.org/en/features-sphinx-doxygen).

Notable changes are visible on the assertion reference:

| Before | After |
| --- | --- |
[Rendered](http://criterion.readthedocs.org/en/latest/assert.html) | [Rendered](http://criterion.readthedocs.org/en/features-sphinx-doxygen/assert.html)
[Source](https://raw.githubusercontent.com/Snaipe/Criterion/bleeding/doc/assert.rst) | [Source](https://raw.githubusercontent.com/Snaipe/Criterion/features/sphinx-doxygen/doc/assert.rst)

It is immediately apparent that with these changes, the sphinx documentation isn't a maintainance hell anymore since everything that is API-related can be automatically generated.
This allows us to be thorough with the documentation without sacrificing maintainability (as the sphinx docs will stay in sync with the API docs), which is a huge plus on my side.

As a bonus, the PDF docs also get a pretty nifty [symbol index](https://media.readthedocs.org/pdf/criterion/features-sphinx-doxygen/criterion.pdf#61)