### PR TITLE
Add coverage info to FAQ in docs

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -16,3 +16,8 @@ There are plenty of ways to fix that behaviour:
 A. Open a new issue on the `github issue tracker <https://github.com/Snaipe/Criterion/issues>`_,
 and describe the problem you are experiencing, along with the platform you are
 running criterion on.
+
+**Q. Why does Gcov show 0% coverage after I run my tests?**
+
+You need to either pass ``--no-early-exit`` or define
+``CRITERION_NO_EARLY_EXIT=1`` in your environment to get proper coverage.


### PR DESCRIPTION
First of all, thank you for this terrific project.

I was trying to determine why my tests weren't generating any coverage data, and I found the answer [here](https://github.com/Snaipe/Criterion/pull/84). I didn't see this information anywhere in the official docs, so I added your response to the FAQs in this commit.