### PR TITLE
Remove `restrict` keyword usages

### DIFF
--- a/src/io/xml.c
+++ b/src/io/xml.c
@@ -121,8 +121,8 @@ const char *get_status_string(struct criterion_test_stats *ts,
  * requires a dot as the decimal separator.
  * Therefore we set the locale temporarily to print dots.
  */
-static int fprintf_locale(FILE *restrict stream,
-    const char *restrict format, ...) {
+static int fprintf_locale(FILE *stream,
+                          const char *format, ...) {
     va_list args;
     int result;
     const char *locale = setlocale(LC_NUMERIC, NULL);


### PR DESCRIPTION
This turned out to be a bug in the recent C99 support:
https://connect.microsoft.com/VisualStudio/Feedback/Details/1161593
(ticket probably needs some votes to draw their attention)

Since this is little to no value there for `restrict` anyway, it has
been removed.
