### PR TITLE
Compilation and test fixes for FreeBSD

### DIFF
--- a/.cmake/Modules/Capabilities.cmake
+++ b/.cmake/Modules/Capabilities.cmake
@@ -26,6 +26,7 @@ check_function_exists(strtok_s HAVE_STRTOK_S)
 check_function_exists(strtok_r HAVE_STRTOK_R)
 
 check_library_exists (rt clock_gettime "time.h" HAVE_CLOCK_GETTIME)
+check_library_exists (anl getaddrinfo_a "" HAVE_GETADDRINFO_A)
 
 # Check for C++11
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ cr_link_libraries(criterion pthread IF NOT WIN32)
 cr_link_libraries(criterion rt IF HAVE_CLOCK_GETTIME)
 
 # Required by nanomsg
-cr_link_libraries(criterion anl IF NOT WIN32 AND NOT APPLE)
+cr_link_libraries(criterion anl IF HAVE_GETADDRINFO_A)
 cr_link_libraries(criterion ws2_32 mswsock IF WIN32)
 
 cr_link_package(criterion PCRE)

--- a/test/cram/asserts.t
+++ b/test/cram/asserts.t
@@ -86,7 +86,7 @@ Testing all assert messages
   [\x1b[0;34m----\x1b[0m] \x1b[0;1mfailmessages.cc\x1b[0m:\x1b[0;31m10\x1b[0m: Assertion failed: The expression (1) > (2) is false. (esc)
   [\x1b[0;34m----\x1b[0m] \x1b[0;1mfailmessages.cc\x1b[0m:\x1b[0;31m11\x1b[0m: Assertion failed: The expression (1) >= (2) is false. (esc)
   [\x1b[0;34m----\x1b[0m] \x1b[0;1mfailmessages.cc\x1b[0m:\x1b[0;31m12\x1b[0m: Assertion failed: "" is not null. (esc)
-  [\x1b[0;34m----\x1b[0m] \x1b[0;1mfailmessages.cc\x1b[0m:\x1b[0;31m13\x1b[0m: Assertion failed: __null is null. (esc)
+  \[\\x1b\[0;34m----\\x1b\[0m\] \\x1b\[0;1mfailmessages\.cc\\x1b\[0m:\\x1b\[0;31m13\\x1b\[0m: Assertion failed: (nullptr|__null) is null\. \(esc\) (re)
   [\x1b[0;34m----\x1b[0m] \x1b[0;1mfailmessages.cc\x1b[0m:\x1b[0;31m15\x1b[0m: Assertion failed: The expression (2) - (1) <= (0.1) && (1) - (2) <= (0.1) is false. (esc)
   [\x1b[0;34m----\x1b[0m] \x1b[0;1mfailmessages.cc\x1b[0m:\x1b[0;31m16\x1b[0m: Assertion failed: The expression (2) - (2) > (0.1) || (2) - (2) > (0.1) is false. (esc)
   [\x1b[0;34m----\x1b[0m] \x1b[0;1mfailmessages.cc\x1b[0m:\x1b[0;31m18\x1b[0m: Assertion failed: "foo" (`foo`) is not empty. (esc)


### PR DESCRIPTION
This PR fixes a couple of issues that I encountered when compiling/testing Criterion on a fresh install of FreeBSD 10.3.

The first commit fixes the following build failure:

        Linking C shared library libcriterion.so
        /usr/bin/ld: cannot find -lanl

Which is caused by libanl (part of glibc) not being available.  Since it is only required by nanomsg for `getaddrinfo_a`, I added a check for that symbol to `.cmake/Modules/Capabilities.cmake` and link when present.  This matches the nanomsg behavior.

The second commit fixes a cram test failure in `test/cram/asserts.t` due to the FreeBSD libc defining `NULL` to `nullptr` rathern than `__null` when compiling as C++.  The test now matches against either keyword.

Thanks for considering,
Kevin