### PR TITLE
added --crash cli option (#126)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "dependencies/nanomsg-patched"]
 	path = dependencies/nanomsg-patched
 	url = https://github.com/Snaipe/nanomsg.git
+[submodule "dependencies/debugbreak"]
+	path = dependencies/debugbreak
+	url = https://github.com/scottt/debugbreak

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ include_directories(
   dependencies/valgrind/include/
   dependencies/klib/
   dependencies/nanopb/
+  dependencies/debugbreak/
 )
 
 # Coverage

--- a/include/criterion/options.h
+++ b/include/criterion/options.h
@@ -116,6 +116,14 @@ struct criterion_options {
      *  default: false
      */
     bool wait_for_clients;
+
+    /**
+     * Raise a debug trap to crash the test if an assert fails so that a
+     * debugger can gain control.
+     *
+     * default: false
+     */
+    bool crash;
 };
 
 CR_BEGIN_C_API

--- a/src/core/abort.c
+++ b/src/core/abort.c
@@ -27,11 +27,16 @@
 #include "protocol/messages.h"
 #include "criterion/internal/asprintf-compat.h"
 #include "criterion/criterion.h"
+#include "criterion/options.h"
 #include "io/event.h"
+#include "debugbreak.h"
 
 jmp_buf g_pre_test;
 
 void criterion_abort_test(void) {
+    if (criterion_options.crash)
+        debug_break();
+
     longjmp(g_pre_test, 1);
 }
 

--- a/src/entry/params.c
+++ b/src/entry/params.c
@@ -68,6 +68,8 @@
             "prematurely after the test\n"                  \
     "    --verbose[=level]: sets verbosity to level "       \
             "(1 by default)\n"                              \
+    "    --crash: crash failing assertions rather than "    \
+            "aborting (for debugging purposes)\n"           \
     "    -OP:F or --output=PROVIDER=FILE: write test "      \
             "report to FILE using the specified provider\n"
 
@@ -148,6 +150,7 @@ int criterion_handle_args(int argc, char *argv[], bool handle_unknown_arg) {
         {"no-early-exit",   no_argument,        0, 'z'},
         {"output",          required_argument,  0, 'O'},
         {"wait",            no_argument,        0, 'w'},
+        {"crash",           no_argument,        0, 'c'},
         {0,                 0,                  0,  0 }
     };
 
@@ -271,6 +274,7 @@ int criterion_handle_args(int argc, char *argv[], bool handle_unknown_arg) {
             } break;
             case 'w': criterion_options.wait_for_clients = true; break;
             case '?':
+            case 'c': criterion_options.crash            = true; break;
             default : do_print_usage = handle_unknown_arg; break;
         }
     }

--- a/test/cram/help.t
+++ b/test/cram/help.t
@@ -19,6 +19,7 @@ Display the help message
       --always-succeed: always exit with 0
       --no-early-exit: do not exit the test worker prematurely after the test
       --verbose[=level]: sets verbosity to level (1 by default)
+      --crash: crash failing assertions rather than aborting (for debugging purposes)
       -OP:F or --output=PROVIDER=FILE: write test report to FILE using the specified provider
 
   $ simple.cc.bin --help
@@ -40,6 +41,7 @@ Display the help message
       --always-succeed: always exit with 0
       --no-early-exit: do not exit the test worker prematurely after the test
       --verbose[=level]: sets verbosity to level (1 by default)
+      --crash: crash failing assertions rather than aborting (for debugging purposes)
       -OP:F or --output=PROVIDER=FILE: write test report to FILE using the specified provider
 
 


### PR DESCRIPTION
Crash the test if an assert fails so that an debugger can gain control.
signal() and abort() should be portable.