### PR TITLE
pkgconfig: fix the installation path of criterion.pc

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -139,7 +139,7 @@ configure_file(
   @ONLY
 )
 
-install (FILES "${CMAKE_CURRENT_BINARY_DIR}/criterion.pc" DESTINATION "${CMAKE_INSTALL_PREFIX}/share/pkgconfig")
+install (FILES "${CMAKE_CURRENT_BINARY_DIR}/criterion.pc" DESTINATION "share/pkgconfig")
 
 set (SOURCE_FILES ${SOURCE_FILES} PARENT_SCOPE)
 set (INTERFACE_FILES ${INTERFACE_FILES} PARENT_SCOPE)


### PR DESCRIPTION
If `${CMAKE_INSTALL_PREFIX}` is mentioned explicitly in the install() command, the generated `cmake_install.cmake` file will contain a hard-coded value.

This can cause installation errors during debian package generation, since the `cmake -DCMAKE_INSTALL_PREFIX=../debian/tmp/usr -P cmake_install.cmake` command is used in the debian/rules file (this command overrides the original `CMAKE_INSTALL_PREFIX`).


```
$ cmake -DCOMPONENT=Unspecified -DCMAKE_INSTALL_PREFIX=../debian/tmp/usr -P cmake_install.cmake

-- Installing: /home/anno/Criterion/b/Debian/criterion-2.2.1-2.orig/build_dir/../debian/tmp/usr/lib/libcriterion.so.2.2.1
...

-- Installing: /usr/share/pkgconfig/criterion.pc
CMake Error at src/cmake_install.cmake:44 (file):
  file INSTALL cannot copy file
  "/home/anno/Criterion/b/Debian/criterion-2.2.1-2.orig/build_dir/src/criterion.pc"
  to "/usr/share/pkgconfig/criterion.pc". <--- this is the preconfigured (hard-coded) value
Call Stack (most recent call first):
  cmake_install.cmake:188 (include)
```