### PR TITLE
improve #139: added --crash for cr_expect ( #126)

### DIFF
--- a/include/criterion/abort.h
+++ b/include/criterion/abort.h
@@ -44,7 +44,7 @@ CR_API CR_NORETURN void criterion_abort_test(void);
  *
  *  Used as a counterpart to criterion_abort_test.
  */
-CR_INLINE static void criterion_continue_test(void) {}
+CR_API void criterion_continue_test(void);
 
 /**
  *  Kills the current test, marking it as failed.

--- a/src/core/abort.c
+++ b/src/core/abort.c
@@ -40,6 +40,11 @@ void criterion_abort_test(void) {
     longjmp(g_pre_test, 1);
 }
 
+void criterion_continue_test(void) {
+    if (criterion_options.crash)
+        debug_break();
+}
+
 void criterion_test_die(const char *msg, ...) {
     va_list vl;
     va_start(vl, msg);


### PR DESCRIPTION
Improves PR #139, so that --crash works for cr_expect too.