### PR TITLE
fix: set criterion_options.debug to CR_DBG_NATIVE

### DIFF
--- a/src/entry/params.c
+++ b/src/entry/params.c
@@ -167,7 +167,7 @@ static int parse_dbg_transport(const char *arg)
 static int parse_dbg(const char *arg)
 {
     if (!arg)
-        return CR_DBG_NATIVE;
+        return criterion_options.debug = CR_DBG_NATIVE;
 
     static struct { char *name; enum criterion_debugger dbg; } values[] = {
         { "gdb",    CR_DBG_GDB    },


### PR DESCRIPTION
criterion_options.debug was not set if no argument was given. According
to the docs the native debugger should used, so this member has to be
set to CR_DBG_NATIVE.