### PR TITLE
section: Fix "Aborted" due to too many open files

### DIFF
--- a/src/compat/section-elf.c
+++ b/src/compat/section-elf.c
@@ -123,7 +123,12 @@ int open_module_self(mod_handle *mod)
         return 0;
 
     mod->fd = fd;
-    return open_module_map(mod);
+    if (!open_module_map(mod)) {
+        close(mod->fd);
+        return 0;
+    }
+
+    return 1;
 }
 
 void close_module(mod_handle *mod)

--- a/src/core/report.c
+++ b/src/core/report.c
@@ -44,11 +44,14 @@
         if (!open_module_self(&self))                                           \
             abort();                                                            \
         void *start = map_section_data(&self, CR_HSEC_STR(Kind), &sect);        \
-        if (!start)                                                             \
+        if (!start) {                                                           \
+            close_module(&self);                                                \
             return;                                                             \
+        }                                                                       \
         void *end = (char *) start + sect.sec_len;                              \
         for (f_report_hook *hook = start; hook < (f_report_hook *) end; ++hook) \
             (*hook ? *hook : nothing)(data);                                    \
+        close_module(&self);                                                    \
     }
 
 IMPL_CALL_REPORT_HOOKS(PRE_ALL)

--- a/src/core/runner.c
+++ b/src/core/runner.c
@@ -168,6 +168,8 @@ struct criterion_test_set *criterion_init(void)
         criterion_register_test(set, *test);
     }
 
+    close_module(&self);
+
     return set;
 }
 


### PR DESCRIPTION
Running a test binary with many tests and/or assertions, such as the following example:

```C
#include <criterion/criterion.h>

Test(suite, test) {
    /* Note:  2000 needs to be above current RLIMIT_NOFILE */
    for (unsigned int i = 0; i < 2000; ++i) {
        cr_assert(1);
    }
}
```

on systems with ELF binaries causes the program to abort, usually in `call_report_hooks_*` due to `open_module_self` returning `0` due to `EMFILE` from [`open`](https://github.com/Snaipe/Criterion/blob/c5bfe03/src/compat/section-elf.c#L71).

This PR fixes the issue by calling `close_module` for every successful `open_module_self` call and ensuring that `open_module_self` closes any file descriptors it opens when returning a failure code.

Thanks for considering,
Kevin