### PR TITLE
Do not create sockets in current directory

### DIFF
--- a/src/config.h.in
+++ b/src/config.h.in
@@ -17,4 +17,6 @@
 # define PACKAGE "${PROJECT_NAME}"
 # define VERSION "${PROJECT_VERSION}"
 
+#define NN_SOCKET_PATH "/var/lib/"
+
 #endif /* !CONFIG_H_IN_ */

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -17,6 +17,10 @@
 # define PACKAGE "${PROJECT_NAME}"
 # define VERSION "${PROJECT_VERSION}"
 
-#define NN_SOCKET_PATH "/var/lib/"
+#ifdef _WIN32
+# define NN_SOCKET_PATH ""
+#else
+# define NN_SOCKET_PATH "/tmp/"
+#endif
 
 #endif /* !CONFIG_H_IN_ */

--- a/src/core/runner.c
+++ b/src/core/runner.c
@@ -323,8 +323,8 @@ static int criterion_run_all_tests_impl(struct criterion_test_set *set)
                     _(msg_valgrind_jobs), CR_FG_BOLD, CR_RESET);
     }
 
-    char url[sizeof ("ipc://criterion_.sock") + 21];
-    snprintf(url, sizeof (url), "ipc://criterion_%llu.sock", get_process_id());
+    char url[sizeof ("ipc://" NN_SOCKET_PATH "criterion_.sock") + 21];
+    snprintf(url, sizeof (url), "ipc://" NN_SOCKET_PATH "criterion_%llu.sock", get_process_id());
 
     int sock = cri_proto_bind(url);
     if (sock < 0)


### PR DESCRIPTION
In my environment I am not allowed to create a UNIX socket in the current working directory (mounted Docker volume).

I think creating the nanomsg socket in /tmp/ or /var/lib/ is a better practice.