### PR TITLE
cmake: Replaced CMAKE_CURRENT_SOURCE_DIR with CMAKE_SOURCE_DIR

### DIFF
--- a/.cmake/Modules/Subprojects.cmake
+++ b/.cmake/Modules/Subprojects.cmake
@@ -37,7 +37,7 @@ function (cr_add_subproject _NAME)
       set (epa_opts ${epa_opts} GIT_TAG "${object}")
     endif ()
   elseif (ARGS_PATH)
-      set (epa_opts SOURCE_DIR "${CMAKE_SOURCE_DIR}/${ARGS_PATH}")
+      set (epa_opts SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/${ARGS_PATH}")
   endif ()
 
   if (ARGS_CMAKE)


### PR DESCRIPTION
cr_add_subproejct didn't work correctly when Criterion was used as a git submoudle in another project as follows.

    $ cd my_git_project
    $ mkdir vendor
    $ git submodule add \
        https://github.com/Snaipe/Criterion.git vendor/criterion

You can reproduce the problem by running [a script](https://gist.github.com/MasayukiNagamachi/0fa79ee62ca77a42f2fa1d5e3bac9719).

When you run the script, you can see the following error messages:

```
$ mkdir test
$ sh reproduce.sh test
...
CMake Error at /usr/share/cmake-3.5/Modules/ExternalProject.cmake:1915 (message):
  No download info given for 'csptr' and its source directory:

   /path/to/root/source/dependencies/libcsptr

  is not an existing non-empty directory.  Please specify one of:

   * SOURCE_DIR with an existing non-empty directory
   * URL
   * GIT_REPOSITORY
   * HG_REPOSITORY
   * CVS_REPOSITORY and CVS_MODULE
   * SVN_REVISION
   * DOWNLOAD_COMMAND
Call Stack (most recent call first):
  /usr/share/cmake-3.5/Modules/ExternalProject.cmake:2459 (_ep_add_download_command)
  vendor/criterion/.cmake/Modules/Subprojects.cmake:74 (externalproject_add)
  vendor/criterion/CMakeLists.txt:34 (cr_add_subproject)
...
```

I used CMake 3.5.1 on Xubuntu 16.04 for reproduction of the problem. You can probably reproduce the problem in other environments.

The cause of the problem was the use of CMAKE_SOURCE_DIR. CMAKE_SOURCE_DIR was expanded to the path to the top level of the source tree.

Due to the use of CMAKE_SOURCE_DIR, two `dependencies` folders are created.

The first one is created in the root source directory by CMake and doesn't contains source files of submodules. The other is created in vendor/criterion by git-submodule command and contains source files of submodules.

As a result, CMake reports the above error messages.

The problem was fixed by replacing CMAKE_SOURCE_DIR with CMAKE_CURRENT_SOURCE_DIR which was expanded to the path to the source directory currently being processed.

By this patch, only one`dependencies` folder is created in CMAKE_SOURCE_DIR, and the folder contains source files of submodules.