### PR TITLE
doc: Fix minor errors in debug.rst.

### DIFF
--- a/doc/debug.rst
+++ b/doc/debug.rst
@@ -6,7 +6,7 @@ Debugging and Coverage information
 .. note::
 
     The following section assumes you have the relevant debugging server
-    installed on your server. For instance, if you're debugging with gdb,
+    installed on your machine. For instance, if you're debugging with gdb,
     you'll need to have ``gdbserver`` installed and available in your PATH.
 
 Debugging with GDB
@@ -58,7 +58,7 @@ And a new process is created for the next test:
     Process /path/to/test created; pid = 26414
     Listening on port 1234
 
-Connect your remote debugger to this test with ``remote target localhost:1234``
+Connect your remote debugger to this test with ``target remote localhost:1234``
 and run the test with ``continue``
 
 To use a different port use ``--debug --debug-transport=<protocol>:<port>``


### PR DESCRIPTION
'debugging server installed on your server' -> 'debugging server installed on
your machine'. Considered changing the first mention of "server" to "software"
but noticed that the "software" is more often called "server" (gdb, lldb). So I
changed the second "server" instead as a matter of style (also, Criterion won't
always be used in a _server_).

'remote target localhost:1234' -> 'target remote localhost:1234'. The given
command is just wrong and unrecognized by gdb.