### PR TITLE
Make cr_file_match_str fail if str is longer.

### DIFF
--- a/samples/redirect.cc
+++ b/samples/redirect.cc
@@ -32,7 +32,7 @@ void rot13_io(void)
 {
     std::string s;
 
-    std::cin >> s;
+    std::getline(std::cin, s);
     for (size_t i = 0; i < s.length(); ++i)
         s[i] = rot13_char(s[i]);
     std::cout << s << std::flush;

--- a/src/io/file.c
+++ b/src/io/file.c
@@ -22,6 +22,11 @@ int cr_file_match_str(FILE *f, const char *str)
     /* consume the rest of what's available */
     while (fread(buf, 1, sizeof (buf), f) > 0) ;
 
+    /* there are more bytes in str than in f */
+    if (len) {
+        return 0;
+    }
+
     return matches;
 }
 


### PR DESCRIPTION
When using `cr_file_match_str`, if the provided string we want to match the file against is longer than the contents of the file, the function returns that the file matches the string.

This function is used by many other assertion routines (namely those asserting the contents of the standard output streams). This can be very error-prone when designing tests such as the following:

```c
Test(criterion, cr_file_match_str, .init = cr_redirect_stdout)
{
  printf("%s%d%s", "string", 42, "other");
  fflush(stdout);
  cr_assert_stdout_eq_str("string42othernonsense");
}
```

This commit makes it so that `cr_file_match_str` detects this kind of mismatch.

Note: It does not alter the fact that the function consumes all of the stream.