### PR TITLE
Look for libintl headers in the correct location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,7 @@ endif()
 # I18N
 
 if (I18N AND GETTEXT_FOUND AND LIBINTL_LIB_FOUND)
+  include_directories(SYSTEM ${LIBINTL_INCLUDE_DIR})
   include(GettextTranslate)
   add_subdirectory(po)
 endif ()


### PR DESCRIPTION
If libintl.h is not in the default search path, we need to look for it in the right location.