### PR TITLE
Make `cr_file_match_str` succeed when both file and string are empty.

### DIFF
--- a/src/io/file.c
+++ b/src/io/file.c
@@ -6,7 +6,7 @@ int cr_file_match_str(FILE *f, const char *str)
 
     char buf[512];
     size_t read;
-    int matches = 0;
+    int matches = 1;
 
     while ((read = fread(buf, 1, sizeof (buf), f)) > 0) {
         matches = !strncmp(buf, str, read);
@@ -20,7 +20,8 @@ int cr_file_match_str(FILE *f, const char *str)
     }
 
     /* consume the rest of what's available */
-    while (fread(buf, 1, sizeof (buf), f) > 0) ;
+    if (read)
+        while (fread(buf, 1, sizeof (buf), f) > 0) ;
 
     /* there are more bytes in str than in f */
     if (len) {

--- a/test/redirect.cc
+++ b/test/redirect.cc
@@ -87,3 +87,8 @@ Test(redirect, stdin_) {
 
     cr_expect_eq(read, "Foo");
 }
+
+Test(redirect, stdout_empty) {
+    cr_redirect_stdout();
+    cr_expect_stdout_eq_str("");
+}


### PR DESCRIPTION
The following test would not run correctly:

```c
Test(putstr_second, test_outputs, .init = cr_redirect_stdout) {
  cr_assert_stdout_eq_str("");
}
```

This is due to the `matches` variable being set to 0 by default. When
the file is empty, the main loop is not run and `matches` never gets the
chance to be updated. The function thus returned that the file and the
string do not match.

A unit tests has been added to prevent further regression.

An `if` statement has also been added before the consuming loop in
`cr_file_match_str` which avoids an unnecessary call to `fread` if we
already know that the stream is empty.

EDIT:
Would it be possible for `ctest` to automatically run this command before executing:

```
cmake --build . --target criterion_tests
```

I've had all the tests failing before I ran that beacause `ctest` was not able to find the binaries.