### PR TITLE
Fixes stream.h include so it can be found.

### DIFF
--- a/include/criterion/new/assert.h
+++ b/include/criterion/new/assert.h
@@ -433,7 +433,7 @@
 #endif /* !CRITERION_DOCGEN */
 
 #include "memory.h"
-#include "../internal/assert/stream.h"
+#include "stream.h"
 
 /* Internals */
 

--- a/include/criterion/new/assert.h
+++ b/include/criterion/new/assert.h
@@ -433,7 +433,7 @@
 #endif /* !CRITERION_DOCGEN */
 
 #include "memory.h"
-#include "stream.h"
+#include "../internal/assert/stream.h"
 
 /* Internals */
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -136,6 +136,7 @@ set(INTERFACE_FILES
   include/criterion/logging.h
   include/criterion/new/assert.h
   include/criterion/new/memory.h
+  include/criterion/new/stream.h
   include/criterion/options.h
   include/criterion/output.h
   include/criterion/parameterized.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -118,6 +118,7 @@ set(INTERFACE_FILES
   include/criterion/internal/assert/tag.h
   include/criterion/internal/assert/tostr.h
   include/criterion/internal/assert/types.h
+  include/criterion/internal/assert/stream.h
   include/criterion/internal/capabilities.h
   include/criterion/internal/common.h
   include/criterion/internal/deprecation.h


### PR DESCRIPTION
While working on another project I started having issues with your latest code. I found that the recently added stream.h was not added to the CMakeList.txt and it was not well referenced in the assert.c file. I fixes those for my project.