### PR TITLE
Add missing parameter to the documented interface.

### DIFF
--- a/include/criterion/assert.h
+++ b/include/criterion/assert.h
@@ -1101,11 +1101,12 @@
  *
  * @param[in] Actual Array to test
  * @param[in] Expected Expected array
+ * @param[in] Size Number of bytes to check
  * @param[in] FormatString (optional) printf-like format string
  * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-#define cr_assert_arr_eq(Actual, Expected, FormatString, ...)    internal
+#define cr_assert_arr_eq(Actual, Expected, Size, FormatString, ...)    internal
 
 /**
  * Passes if Actual is byte-to-byte equal to Expected
@@ -1120,11 +1121,12 @@
  *
  * @param[in] Actual Array to test
  * @param[in] Expected Expected array
+ * @param[in] Size Number of bytes to check
  * @param[in] FormatString (optional) printf-like format string
  * @param[in] ... (optional) format string parameters
  *
  *****************************************************************************/
-#define cr_expect_arr_eq(Actual, Expected, FormatString, ...)    internal
+#define cr_expect_arr_eq(Actual, Expected, Size, FormatString, ...)    internal
 
 /**
  * Passes if Actual is not byte-to-byte equal to Expected


### PR DESCRIPTION
cr_(assert/expect)_mem_(n)eq are implemented by calls to
cr_assert_mem_op_va_. But while the documentation of
cr_(assert/expect)_mem_neq contains the third parameter Size, the
documentation for cr_(assert/expect)_mem_eq does not.

This fix only touches the "declaration" and the documentation of
cr_assert_arr_eq and cr_expect_arr_eq.