### PR TITLE
Add directory support to test reports

### DIFF
--- a/include/criterion/internal/asprintf-compat.h
+++ b/include/criterion/internal/asprintf-compat.h
@@ -43,6 +43,8 @@ CR_API void cr_asprintf_free(char *buf);
 
 CR_API int cri_fmt_bprintf(char **buf, size_t *offset, size_t *sz,
         const char *fmt, ...);
+CR_API int cri_fmt_vbprintf(char **buf, size_t *offset, size_t *sz,
+        const char *fmt, va_list ap);
 
 CR_API char *cri_strtok_r(char *str, const char *delim, char **saveptr);
 

--- a/include/criterion/options.h
+++ b/include/criterion/options.h
@@ -218,6 +218,8 @@ struct criterion_options {
      * default: false
      */
     bool ignore_warnings;
+
+    const char *executable_name;
 };
 
 CR_BEGIN_C_API

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,8 +33,8 @@ set(SOURCE_FILES
   src/compat/strtok.h
   src/compat/process.c
   src/compat/process.h
-  src/compat/basename.c
-  src/compat/basename.h
+  src/compat/path.c
+  src/compat/path.h
   src/compat/mockfile.c
   src/compat/time.c
   src/compat/time.h

--- a/src/compat/path.c
+++ b/src/compat/path.c
@@ -23,8 +23,10 @@
  */
 #include <stdlib.h>
 #include <string.h>
+#include <stdarg.h>
 
 #include "path.h"
+#include "err.h"
 #include "config.h"
 #include "string/fmt.h"
 
@@ -33,6 +35,21 @@
 # include <limits.h>
 #elif defined (HAVE_GETCURRENTDIRECTORY)
 # include <windows.h>
+#endif
+
+#if defined (_WIN32) && !defined (__CYGWIN__)
+# include <windows.h>
+#else
+# include <unistd.h>
+
+# include <sys/types.h>
+# include <sys/stat.h>
+#endif
+
+#if defined (_WIN32) || defined (__CYGWIN__)
+# define CRI_PATH_SEPARATOR '\\'
+#else
+# define CRI_PATH_SEPARATOR '/'
 #endif
 
 const char *basename_compat(const char *str)
@@ -137,4 +154,163 @@ char *cri_path_relativeof(const char *cstpath)
     free(path);
 
     return rel;
+}
+
+bool cri_path_isdirectory(const char *path)
+{
+#if defined (_WIN32) && !defined (__CYGWIN__)
+    DWORD attr = GetFileAttributesA(path);
+    return attr != INVALID_FILE_ATTRIBUTES && (attr & FILE_ATTRIBUTE_DIRECTORY);
+#else
+    struct stat sb;
+    return stat(path, &sb) == 0 && S_ISDIR(sb.st_mode);
+#endif
+}
+
+bool cri_path_exists(const char *path)
+{
+#if defined (_WIN32) && !defined (__CYGWIN__)
+    DWORD attr = GetFileAttributesA(path);
+    return attr != INVALID_FILE_ATTRIBUTES;
+#else
+    struct stat sb;
+    return stat(path, &sb) == 0;
+#endif
+}
+
+
+static inline size_t first_non_separator_index(const char *str)
+{
+    size_t idx = 0;
+    while (str[idx] && (str[idx] == '/' || str[idx] == '\\'))
+        ++idx;
+
+    return idx;
+}
+
+static inline size_t first_trailing_separator_index(const char *str)
+{
+    size_t idx = strlen(str);
+    while (idx > 0 && (str[idx - 1] == '/' || str[idx - 1] == '\\'))
+        --idx;
+
+    return idx;
+}
+
+static inline void append_buf_printf(char **buf, size_t *off, size_t *size, const char *fmt, ...)
+{
+    va_list vl;
+
+    va_start(vl, fmt);
+    int rc = cri_fmt_vbprintf(buf, off, size, fmt, vl);
+    va_end(vl);
+
+    assert(rc == 0);
+}
+
+static inline void append_buf_len(char **buf, size_t *off, size_t *size, const char *str, size_t str_len)
+{
+    append_buf_printf(buf, off, size, "%.*s", (int) str_len, str);
+}
+
+static inline void append_buf(char **buf, size_t *off, size_t *size, const char *str)
+{
+    append_buf_printf(buf, off, size, "%s", str);
+}
+
+/*
+ * cri_path_build_va():
+ * - skips empty elements
+ * - the boundary between two elements is cleaned (separators are removed), one separator is inserted
+ * - separators at the beginning and the end of the path are not removed
+ */
+static size_t cri_path_build_va(char separator, char **output, size_t *size, const char *first_path_part, va_list *vl)
+{
+    if (!first_path_part)
+        return 0;
+
+    size_t off = 0;
+    size_t last_end_idx = 0;
+    bool is_first_non_empty = true, leading = false;
+    const char *last_path_part = first_path_part;
+
+    while (true) {
+        const char *path_part = first_path_part ? first_path_part : va_arg(*vl, const char *);
+        first_path_part = NULL;
+
+        if (!path_part)
+            break;
+
+        if (!*path_part)
+            continue;
+
+        last_path_part = path_part;
+
+        size_t begin_idx = first_non_separator_index(path_part);
+        size_t end_idx = first_trailing_separator_index(path_part);
+        last_end_idx = end_idx;
+
+        if (!leading) {
+            append_buf_len(output, &off, size, path_part, begin_idx);
+            leading = true;
+        }
+
+        if (begin_idx >= end_idx) {
+            last_end_idx = is_first_non_empty ? begin_idx : end_idx;
+            continue;
+        }
+
+        if (!is_first_non_empty)
+            append_buf_len(output, &off, size, &separator, 1);
+
+        is_first_non_empty = false;
+
+        append_buf_len(output, &off, size, path_part + begin_idx, end_idx - begin_idx);
+    }
+
+    append_buf(output, &off, size, last_path_part + last_end_idx);
+
+    return off;
+}
+
+size_t cri_path_combine(char **output, size_t *size, const char *first_path_part, ...)
+{
+    va_list vl;
+
+    va_start(vl, first_path_part);
+    size_t off = cri_path_build_va(CRI_PATH_SEPARATOR, output, size, first_path_part, &vl);
+    va_end(vl);
+
+    return off;
+}
+
+size_t cri_path_build(char separator, char **output, size_t *size, const char *first_path_part, ...)
+{
+    va_list vl;
+
+    va_start(vl, first_path_part);
+    size_t off = cri_path_build_va(separator, output, size, first_path_part, &vl);
+    va_end(vl);
+
+    return off;
+}
+
+char *cri_path_gen_unique_filename(const char *path, const char *filename, const char *extension)
+{
+    char *unique_path = NULL;
+    size_t size = 0;
+
+    size_t counter = 0;
+
+    do {
+        size_t path_end = cri_path_combine(&unique_path, &size, path, filename, NULL);
+        if (counter)
+            cri_fmt_bprintf(&unique_path, &path_end, &size, "_%d.%s", counter, extension);
+        else
+            cri_fmt_bprintf(&unique_path, &path_end, &size, ".%s", extension);
+
+        ++counter;
+    } while (cri_path_exists(unique_path));
+
+    return unique_path;
 }

--- a/src/compat/path.c
+++ b/src/compat/path.c
@@ -24,7 +24,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "basename.h"
+#include "path.h"
 #include "config.h"
 #include "string/fmt.h"
 

--- a/src/compat/path.h
+++ b/src/compat/path.h
@@ -28,8 +28,15 @@
 #include <stdbool.h>
 
 const char *basename_compat(const char *str);
+
 char *cri_path_cwd(void);
 bool cri_path_isrelative(const char *path);
+bool cri_path_isdirectory(const char *path);
+bool cri_path_exists(const char *path);
 char *cri_path_relativeof(const char *path);
+size_t cri_path_combine(char **output, size_t *size, const char *path, ...);
+char *cri_path_gen_unique_filename(const char *path, const char *filename, const char *extension);
+
+size_t cri_path_build(char separator, char **output, size_t *size, const char *path, ...);
 
 #endif /* !COMPAT_PATH_H_ */

--- a/src/compat/path.h
+++ b/src/compat/path.h
@@ -21,8 +21,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#ifndef BASENAME_H_
-#define BASENAME_H_
+#ifndef COMPAT_PATH_H_
+#define COMPAT_PATH_H_
 
 #include <stddef.h>
 #include <stdbool.h>
@@ -32,4 +32,4 @@ char *cri_path_cwd(void);
 bool cri_path_isrelative(const char *path);
 char *cri_path_relativeof(const char *path);
 
-#endif /* !BASENAME_H_ */
+#endif /* !COMPAT_PATH_H_ */

--- a/src/compat/posix.h
+++ b/src/compat/posix.h
@@ -90,6 +90,6 @@
 #include "compat/pipe.h"
 #include "compat/section.h"
 #include "compat/process.h"
-#include "compat/basename.h"
+#include "compat/path.h"
 
 #endif /* !POSIX_COMPAT_H_ */

--- a/src/entry/params.c
+++ b/src/entry/params.c
@@ -363,6 +363,8 @@ CR_API int criterion_handle_args(int argc, char *argv[],
         free(out);
     }
 
+    criterion_options.executable_name = argv[0];
+
     for (int c; (c = getopt_long(argc, argv, "hvlfj:SqO:wt:", opts, NULL)) != -1;) {
         switch (c) {
             case 'b': criterion_options.logging_threshold = (enum criterion_logging_level) atou(DEF(optarg, "1")); break;

--- a/src/io/output.c
+++ b/src/io/output.c
@@ -26,9 +26,11 @@
 #include <khash.h>
 #include <kvec.h>
 #include <errno.h>
+#include "criterion/options.h"
 #include "criterion/output.h"
 #include "log/logging.h"
 #include "string/i18n.h"
+#include "compat/path.h"
 
 typedef const char *const msg_t;
 
@@ -123,6 +125,19 @@ void process_all_output(struct criterion_global_stats *stats)
                 f = stdout;
             } else if (!strcmp(path, "/dev/stderr")) {
                 f = stderr;
+            } else if (cri_path_isdirectory(path)) {
+                const char *short_executable_name = basename_compat(criterion_options.executable_name);
+                char *output_path = cri_path_gen_unique_filename(path, short_executable_name, name);
+                f = fopen(output_path, "w");
+
+                if (!f) {
+                    int errno2 = errno;
+                    criterion_perror(_(msg_err), output_path, name, strerror(errno2));
+                    free(output_path);
+                    continue;
+                }
+
+                free(output_path);
             } else {
                 f = fopen(path, "w");
             }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,6 +16,8 @@ include_directories(../include ../src)
 
 set(TEST_SOURCES
     ordered-set.c
+    path.c
+    ${PROJECT_SOURCE_DIR}/src/compat/path.c # TODO: static lib
 )
 
 if (THEORIES)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,7 +17,9 @@ include_directories(../include ../src)
 set(TEST_SOURCES
     ordered-set.c
     path.c
-    ${PROJECT_SOURCE_DIR}/src/compat/path.c # TODO: static lib
+    # TODO: static lib from internals
+    ${PROJECT_SOURCE_DIR}/src/compat/path.c
+    ${PROJECT_SOURCE_DIR}/src/err.c
 )
 
 if (THEORIES)

--- a/test/path.c
+++ b/test/path.c
@@ -1,0 +1,18 @@
+#include "criterion/criterion.h"
+#include "compat/path.h"
+
+Test(path, basename_compat)
+{
+    cr_expect_str_eq(basename_compat("/a/b/c/dir/basename.ext"), "basename.ext");
+    cr_expect_str_eq(basename_compat("C:\\a\\b\\c\\dir\\basename.ext"), "basename.ext");
+    cr_expect_str_eq(basename_compat("C:\\a\\b\\c/dir/basename.ext"), "basename.ext");
+
+    cr_expect_str_eq(basename_compat("/a/basename/"), "basename/");
+    cr_expect_str_eq(basename_compat("./"), "./");
+    cr_expect_str_eq(basename_compat("../../"), "../");
+
+    cr_expect_str_eq(basename_compat("a//b\\\\base"), "base");
+
+    cr_expect_str_eq(basename_compat("basename"), "basename");
+    cr_expect_str_eq(basename_compat(""), "");
+}

--- a/test/path.c
+++ b/test/path.c
@@ -1,3 +1,5 @@
+#include <stddef.h>
+
 #include "criterion/criterion.h"
 #include "compat/path.h"
 
@@ -15,4 +17,61 @@ Test(path, basename_compat)
 
     cr_expect_str_eq(basename_compat("basename"), "basename");
     cr_expect_str_eq(basename_compat(""), "");
+}
+
+Test(path, cri_path_build)
+{
+    const char s = '/';
+    char *o = NULL;
+    size_t ss = 0;
+
+    cr_expect_eq(cri_path_build(s, &o, &ss, NULL), 0);
+
+    cri_path_build(s, &o, &ss, "", NULL); cr_expect_str_eq(o, "");
+    cri_path_build(s, &o, &ss, " ", NULL); cr_expect_str_eq(o, " ");
+    cri_path_build(s, &o, &ss, "/", NULL); cr_expect_str_eq(o, "/");
+    cri_path_build(s, &o, &ss, "//", NULL); cr_expect_str_eq(o, "//");
+    cri_path_build(s, &o, &ss, "///", NULL); cr_expect_str_eq(o, "///");
+
+    cri_path_build(s, &o, &ss, "a", NULL); cr_expect_str_eq(o, "a");
+    cri_path_build(s, &o, &ss, "//a//", NULL); cr_expect_str_eq(o, "//a//");
+
+    cri_path_build(s, &o, &ss, "/a", "b", "c", NULL); cr_expect_str_eq(o, "/a/b/c");
+    cri_path_build(s, &o, &ss, "a", "b", "c/", NULL); cr_expect_str_eq(o, "a/b/c/");
+    cri_path_build(s, &o, &ss, "/a", "b", "c/", NULL); cr_expect_str_eq(o, "/a/b/c/");
+
+    cri_path_build(s, &o, &ss, "a/b", "c//d", "e", NULL); cr_expect_str_eq(o, "a/b/c//d/e");
+    cri_path_build(s, &o, &ss, "/a/b", "//c//d//", "e//", NULL); cr_expect_str_eq(o, "/a/b/c//d/e//");
+
+    cri_path_build(s, &o, &ss, "/", "a", "/", NULL); cr_expect_str_eq(o, "/a/");
+    cri_path_build(s, &o, &ss, "//", "a", "//", NULL); cr_expect_str_eq(o, "//a//");
+    cri_path_build(s, &o, &ss, "///", "a", "///", NULL); cr_expect_str_eq(o, "///a///");
+
+    cri_path_build(s, &o, &ss, "a", "///", NULL); cr_expect_str_eq(o, "a///");
+    cri_path_build(s, &o, &ss, "///", "a", NULL); cr_expect_str_eq(o, "///a");
+
+    cri_path_build(s, &o, &ss, "a", "///", "b", NULL); cr_expect_str_eq(o, "a/b");
+    cri_path_build(s, &o, &ss, "a", "/", "b", NULL); cr_expect_str_eq(o, "a/b");
+
+    cri_path_build(s, &o, &ss, "", "a", "", "b//", "/", "", NULL); cr_expect_str_eq(o, "a/b/");
+    cri_path_build(s, &o, &ss, "a", "b/", "", "/", "///", "c", NULL); cr_expect_str_eq(o, "a/b/c");
+
+    cri_path_build(s, &o, &ss, "a", "b", "c", NULL); cr_expect_str_eq(o, "a/b/c");
+    cri_path_build(s, &o, &ss, "/a/", "/b/", "/c", "d/", "e", NULL); cr_expect_str_eq(o, "/a/b/c/d/e");
+    cri_path_build(s, &o, &ss, "//a//", "//b//", "//c//", NULL); cr_expect_str_eq(o, "//a/b/c//");
+
+    free(o);
+}
+
+Test(path, cri_path_build_win)
+{
+    const char s = '\\';
+    char *o = NULL;
+    size_t ss = 0;
+
+    cri_path_build(s, &o, &ss, "C:\\", "\\Users\\", "Snaipe", NULL); cr_expect_str_eq(o, "C:\\Users\\Snaipe");
+    cri_path_build(s, &o, &ss, "C:/", "\\Users//", "Snaipe\\", NULL); cr_expect_str_eq(o, "C:\\Users\\Snaipe\\");
+    cri_path_build(s, &o, &ss, "\\", "//test\\", "\\", NULL); cr_expect_str_eq(o, "\\test\\");
+
+    free(o);
 }


### PR DESCRIPTION
This PR adds directory support to test reports (`CRITERION_OUTPUTS`, `--output`).

The functionality is the same as in GTest (GTEST_OUTPUT):

`--output=PROVIDER:PATH`: Write a test report to `PATH` using the output provider named by `PROVIDER`.
If `PATH` is an existing directory, the report will be created in that directory.

The report file will be named after the binary. For example: test_foo --> test_foo.xml

If the file already exists, Criterion will pick a different name (test_foo_1.xml, test_foo_2.xml) to avoid overwriting it.

----------------------

Adding a dynamically sized string class to Criterion was an enormous overkill, but it made the implementation of `cri_path_gen_unique_filename()` and `cri_path_combine()` much cleaner.

I hope I haven't broken Criterion's KISS principle too much. :(

Questions:
- Currently, the generated file extension is the name of the provider. Is that OK? Should I add a `default_extension`) parameter to `criterion_register_output_provider`?

Improvement ideas:
- The parameter list of `cri_path_build()` is NULL-terminated.
  I'm thinking of creating a macro `#define cri_path_combine(...) cri_path_build(CRI_PATH_SEPARATOR, ##__VA_ARGS__, NULL)`, but this is not standard C99.
  I've read your [blog post](https://snai.pe/c/preprocessor/varargs/) about varargs. I think `Length parameter + Macro` is what I need here.
  Is there an existing implementation of this approach in Criterion that I can use?

--------------------

- [x]  The new string facility seems a bit redundant here; I think you might be better off using cri_fmt_bprintf(&buf, &offset, &size, <format>, ...), which essentially appends to buf the formatted string, resizing it as needed.

- [x]  Some of those commits don't really make sense by themselves. I think it would be best to squash those (except the appveyor one, because this one is pretty much standalone)

- [x]  Remove the stylecheck commit -- I'll address that in another change, see below.
