### PR TITLE
appveyor: checkout quietly

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ clone_script:
         if (-not $env:APPVEYOR_PULL_REQUEST_NUMBER) {
             git clone -q --recursive --depth=5 --single-branch --branch=$env:APPVEYOR_REPO_BRANCH https://github.com/$env:APPVEYOR_REPO_NAME.git $env:APPVEYOR_BUILD_FOLDER
             git checkout -qf $env:APPVEYOR_REPO_COMMIT
-            git checkout -B $env:APPVEYOR_REPO_BRANCH
+            git checkout -qB $env:APPVEYOR_REPO_BRANCH
         } else {
             git clone -q --recursive https://github.com/$env:APPVEYOR_REPO_NAME.git $env:APPVEYOR_BUILD_FOLDER
             git fetch -q origin +refs/pull/$env:APPVEYOR_PULL_REQUEST_NUMBER/merge:


### PR DESCRIPTION
I'm really sorry, I did break AppVeyor on the `bleeding` branch. 😞 

Many git commands send their output to stderr even if it's not a real error.
PowerShell seems to react fatally to this (NativeCommandError).