### PR TITLE
io: fix cr_file_match_file matching only the last block.

### DIFF
--- a/src/io/file.c
+++ b/src/io/file.c
@@ -44,8 +44,9 @@ int cr_file_match_file(FILE *f, FILE *ref)
     rewind(ref);
 
     size_t read1 = 1, read2 = 1;
-    int matches = 0;
-    while ((read1 = fread(buf1, 1, sizeof (buf1), f)) > 0
+    int matches = 1;
+    while (matches
+            && (read1 = fread(buf1, 1, sizeof (buf1), f)) > 0
             && (read2 = fread(buf2, 1, sizeof (buf2), ref)) > 0) {
         if (read1 != read2) {
             matches = 0;


### PR DESCRIPTION
With each iteration of the loop, `match` was unconditionally reassigned
to whatever the return of `!memcmp(buf1, buf2, read1)` was. This causes
the result of comparing previous blocks to be overwritten without being
checked.

This PR exits the loop early as soon as a difference is found.

This case isn't trivial to test since it requires files larger than a
block (512o) to be matched. I have tested it locally by manually setting
the buffer sizes to 2 and with smaller files.
I don't know how to add tests for it alongside existing tests in this
project but would gladly do it if provided guidance.