### PR TITLE
Addition of JSON flag in the program's usage

### DIFF
--- a/src/entry/params.c
+++ b/src/entry/params.c
@@ -77,6 +77,8 @@
     "(no file or \"-\" means stderr)\n"                     \
     "    --xml[=FILE]: writes XML report in FILE "          \
     "(no file or \"-\" means stderr)\n"                     \
+    "    --json[=FILE]: writes JSON report in FILE "        \
+    "(no file or \"-\" means stderr)\n"                     \
     "    --always-succeed: always exit with 0\n"            \
     "    --verbose[=level]: sets verbosity to level "       \
     "(1 by default)\n"                                      \

--- a/test/cram/help.t
+++ b/test/cram/help.t
@@ -19,6 +19,7 @@ Display the help message
       --timeout [TIMEOUT]: set a timeout (in seconds) for all tests
       --tap[=FILE]: writes TAP report in FILE (no file or "-" means stderr)
       --xml[=FILE]: writes XML report in FILE (no file or "-" means stderr)
+      --json[=FILE]: writes JSON report in FILE (no file or "-" means stderr)
       --always-succeed: always exit with 0
       --verbose[=level]: sets verbosity to level (1 by default)
       --crash: crash failing assertions rather than aborting (for debugging purposes)
@@ -47,6 +48,7 @@ Display the help message
       --timeout [TIMEOUT]: set a timeout (in seconds) for all tests
       --tap[=FILE]: writes TAP report in FILE (no file or "-" means stderr)
       --xml[=FILE]: writes XML report in FILE (no file or "-" means stderr)
+      --json[=FILE]: writes JSON report in FILE (no file or "-" means stderr)
       --always-succeed: always exit with 0
       --verbose[=level]: sets verbosity to level (1 by default)
       --crash: crash failing assertions rather than aborting (for debugging purposes)
@@ -78,6 +80,7 @@ Display usage on invalid CLI flags
       --timeout [TIMEOUT]: set a timeout (in seconds) for all tests
       --tap[=FILE]: writes TAP report in FILE (no file or "-" means stderr)
       --xml[=FILE]: writes XML report in FILE (no file or "-" means stderr)
+      --json[=FILE]: writes JSON report in FILE (no file or "-" means stderr)
       --always-succeed: always exit with 0
       --verbose[=level]: sets verbosity to level (1 by default)
       --crash: crash failing assertions rather than aborting (for debugging purposes)


### PR DESCRIPTION
The usage now displays information about the `--json` flag.

Before, no information about the `--json` flag was mentioned in the criterion program's usage.