### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/src/compat/section-elf.c
+++ b/src/compat/section-elf.c
@@ -35,6 +35,7 @@
 #include <unistd.h>
 
 #ifdef __FreeBSD__
+# include <sys/sysctl.h>
 # include <sys/elf_generic.h>
 # define ElfW(type)      ElfW_(Elf, type)
 # define ElfW_(e, t)     ElfW__(e, _ ## t)


### PR DESCRIPTION
```
In file included from /tmp/x/Criterion/src/compat/section.c:26:
/tmp/x/Criterion/src/compat/section-elf.c:65:20: error: use of undeclared identifier 'CTL_KERN'
    int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1 };
                   ^
/tmp/x/Criterion/src/compat/section-elf.c:65:30: error: use of undeclared identifier 'KERN_PROC'
    int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1 };
                             ^
/tmp/x/Criterion/src/compat/section-elf.c:65:41: error: use of undeclared identifier 'KERN_PROC_PATHNAME'
    int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1 };
                                        ^
/tmp/x/Criterion/src/compat/section-elf.c:67:5: warning: implicit declaration of function 'sysctl' is invalid in C99 [-Wimplicit-function-declaration]
    sysctl(mib, sizeof (mib) / sizeof (int), self, &cb, NULL, 0);
    ^
1 warning and 3 errors generated.
```

This does not fix the build of the ~~master~~ bleeding branch (which currently does not compile on FreeBSD), but this change allows to build the latest tagged release on FreeBSD.