### PR TITLE
WIP: Handle exit status changes after the end of a test

### DIFF
--- a/src/core/client.c
+++ b/src/core/client.c
@@ -494,6 +494,15 @@ bool handle_death(struct server_ctx *sctx, struct client_ctx *ctx, const criteri
                 break;
             }
             ctx->tstats->exit_code = death->status;
+            if (ctx->tstats->test->data->exit_code != death->status &&
+                    ctx->tstats->test_status == CR_STATUS_PASSED) {
+                --ctx->gstats->tests_passed;
+                --ctx->sstats->tests_passed;
+                ++ctx->gstats->tests_failed;
+                ++ctx->sstats->tests_failed;
+
+                ctx->tstats->test_status = CR_STATUS_FAILED;
+            }
             if (ctx->state == CS_MAIN) {
                 double elapsed_time = 0;
                 push_event(POST_TEST, .data = &elapsed_time);


### PR DESCRIPTION
I'm sure there is a better way to fix that, but it works and allow you to detect if the test crashed after the end of a test.
This fix creates an edge effect, if an exit test in the init or finish, it will be marked as FAILED instead of PASSED.
This can resolve #220 

Edit: Need more work to integrate this