### PR TITLE
Update the share directory location

### DIFF
--- a/dev/autotools/autogen.sh
+++ b/dev/autotools/autogen.sh
@@ -2,9 +2,10 @@
 
 # copy TAP driver into build-aux
 automake_ver=$(automake --version | \grep -E -o '[0-9]\.[0-9]{2}')
+automake_dir=$(dirname $(which automake))/..
 
 mkdir -p build-aux
-cp -f /usr/share/automake-$automake_ver/tap-driver.sh build-aux
+cp -f $automake_dir/share/automake-$automake_ver/tap-driver.sh build-aux
 
 # create criterion TAP log compiler
 # this is necessary to print TAP (and only TAP) on the standard output,


### PR DESCRIPTION
This location depends on the initial install directory of automake. Eg, it can be installed inside /usr/local instead of /usr