### PR TITLE
theories: switch from dyncall to libffi

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -129,11 +129,9 @@ threads = dependency('threads')
 nanomsg = dependency('nanomsg')
 libgit2 = dependency('libgit2')
 boxfort = dependency('boxfort', fallback: ['boxfort', 'boxfort_dep'])
+libffi = dependency('libffi', required: get_option('theories'))
 
-# These libraries are currently broken for not providing a pkg-config file
-dyncall = cc.find_library('dyncall_s', required: get_option('theories'))
-
-config.set('ENABLE_THEORIES', dyncall.found())
+config.set('ENABLE_THEORIES', libffi.found())
 
 # optional platform-dependent standard libs
 librt = cc.find_library('rt', required: false)

--- a/samples/tests/theories_regression.c
+++ b/samples/tests/theories_regression.c
@@ -13,22 +13,25 @@ TheoryDataPoints(theory, misc) = {
     DataPoints(int,          1),
     DataPoints(float,        3.14f),
     DataPoints(double,       3.14),
+    DataPoints(long double,  3.14l),
     DataPoints(char *,       "test"),
     DataPoints(const char *, "other test"),
 };
 
-Theory((char c, bool b, short s, int i, float f, double d, char *str, const char *cstr), theory, misc) {
+Theory((char c, bool b, short s, int i, float f, double d, long double ld, char *str, const char *cstr), theory, misc) {
     float reff = 3.14f;
     double refd = 3.14;
+    long double refld = 3.14l;
 
-    cr_assert(b);
-    cr_assert_eq(c, 'a');
-    cr_assert_eq(s, 1);
-    cr_assert_eq(i, 1);
-    cr_assert_eq(f, reff);
-    cr_assert_eq(d, refd);
-    cr_assert_str_eq(str, "test");
-    cr_assert_str_eq(cstr, "other test");
+    cr_expect(b);
+    cr_expect_eq(c, 'a');
+    cr_expect_eq(s, 1);
+    cr_expect_eq(i, 1);
+    cr_expect_eq(f, reff);
+    cr_expect_eq(d, refd);
+    cr_expect_eq(ld, refld);
+    cr_expect_str_eq(str, "test");
+    cr_expect_str_eq(cstr, "other test");
 
     /* abort to see the formatted string of all parameters */
     cr_assert_fail();

--- a/src/meson.build
+++ b/src/meson.build
@@ -69,7 +69,7 @@ configure_file(input         : 'config.h.in',
 deps = [
 	threads,
 	boxfort,
-	dyncall,
+	libffi,
 	libgit2,
 	nanomsg,
 	librt,


### PR DESCRIPTION
As much as I like dyncall, it just isn't that broadly available on linux
distros. Using libffi has the advantage of being ubiquitous and targets
all of our platforms.

So long, and thanks for all the fish.

---

Some questions remain before this can be merged. Notably, I need to figure out the best way to vendor libffi on a naked windows install (as in, without msys2 or other package managers). A cursory glance seem to indicate that libffi uses autotools. I might need to write a meson wrap file.