### PR TITLE
ci: add ARM and AArch64 builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -32,6 +32,22 @@ Alpine (gcc,i386)_task:
   <<: *pipeline
   test_script: ninja -C build test
 
+Alpine (gcc,arm)_task:
+  container:
+    image: snaipe/ci-meson:alpine-armhf
+  env:
+    CIRRUS_SHELL: /sbin/qemu-sh
+  setup_script: *alpine-deps
+  <<: *pipeline
+
+Alpine (gcc,aarch64)_task:
+  container:
+    image: snaipe/ci-meson:alpine-aarch64
+  env:
+    CIRRUS_SHELL: /sbin/qemu-sh
+  setup_script: *alpine-deps
+  <<: *pipeline
+
 MacOS_task:
   macos_instance:
     image: monterey-xcode-13.1


### PR DESCRIPTION
As explained in #319, I left out the ARM builds because there were non-trivial failures.

To be more precise, exception handling is plainly broken -- criterion doesn't catch anything at all.

Let's figure out why and fix that in this PR.