### PR TITLE
elf: stop assuming that PAGE_SIZE is 4KiB.

### DIFF
--- a/src/compat/section-elf.c
+++ b/src/compat/section-elf.c
@@ -41,6 +41,18 @@
 # define ElfW__(e, t)    e ## t
 #endif
 
+static size_t page_size(void) {
+    static size_t page_size;
+    if (!page_size) {
+        page_size = 0x1000;
+        long v = sysconf(_SC_PAGESIZE);
+        if (v > 0) {
+            page_size = v;
+        }
+    }
+    return page_size;
+}
+
 struct mod_handle {
     int fd;
     const ElfW(Ehdr) * map;
@@ -168,7 +180,7 @@ static void close_module(struct mod_handle *mod)
 static const void *map_shdr(int fd, const ElfW (Shdr) *shdr,
         struct section_mapping *out)
 {
-    size_t shdr_map_off = shdr->sh_offset & ~0xfffllu;
+    size_t shdr_map_off = shdr->sh_offset & ~(page_size() - 1);
     size_t shdr_map_len = shdr->sh_size + (shdr->sh_offset - shdr_map_off);
 
     const uint8_t *shdr_map = mmap(NULL, shdr_map_len,


### PR DESCRIPTION
On some architectures, it's possible to make the kernel use 64KiB pages.
We've had some code in the elf section handling that aligned sections on
4KiB page boundaries regardless, instead of asking for the right page
size through sysconf(3).

Fixes #289.