### PR TITLE
api: use the correct printf specifiers on mingw-gcc.

### DIFF
--- a/include/criterion/internal/asprintf-compat.h
+++ b/include/criterion/internal/asprintf-compat.h
@@ -34,9 +34,22 @@
 
 #include "common.h"
 
+/* MinGW makes the distinction between the printf and gnu_printf archetypes,
+   because they provide a C99-compliant implementation of printf when
+   the __USE_MINGW_ANSI_STDIO macro is defined. Since cr_asprintf calls
+   the vsnprintf function and is compiled in libcriterion, we need to make
+   the choice of which printf function to use.
+
+   Naturally, we use the C99-compliant implementation. */
+#ifdef __MINGW32__
+# define CRI_PRINTF_FORMAT gnu_printf
+#else
+# define CRI_PRINTF_FORMAT printf
+#endif
+
 CR_BEGIN_C_API
 
-CR_FORMAT(printf, 2, 3)
+CR_FORMAT(CRI_PRINTF_FORMAT, 2, 3)
 CR_API int cr_asprintf(char **strp, const char *fmt, ...);
 CR_API int cr_vasprintf(char **strp, const char *fmt, va_list ap);
 CR_API void cr_asprintf_free(char *buf);

--- a/include/criterion/internal/assert/op.h
+++ b/include/criterion/internal/assert/op.h
@@ -353,8 +353,6 @@
         }                                                                   \
     } while (0)
 
-#define CRI_SIZE_T_FMT %zu
-
 #define CRI_ASSERT_SPECIFIER_OPTAG_ARRAY(Op, Name, Tag, ...)                        \
     1; do {                                                                         \
         CRI_ASSERT_NAMESPACES;                                                      \
@@ -372,8 +370,8 @@
         struct cri_assert_node *cri_node = cri_tmp;                                 \
         for (size_t cri_i = 0; cri_i < cri_size; ++cri_i) {                         \
             cri_assert_node_init(&cri_tmpn);                                        \
-            cr_asprintf((char **) &cri_tmpn.repr, "%s ["                            \
-                    CR_STR(CRI_SIZE_T_FMT) "]", cri_repr, cri_i);                   \
+            cr_asprintf((char **) &cri_tmpn.repr, "%s [%" CRI_PRIuSIZE "]",         \
+                    cri_repr, cri_i);                                               \
             cri_tmpn.dynrepr = 1;                                                   \
             cri_paramidx = 0;                                                       \
             CRITERION_APPLY(CRI_ASSERT_IT_MKNODE_SUBSCRIPT, Tag, __VA_ARGS__)       \

--- a/include/criterion/internal/assert/tag.h
+++ b/include/criterion/internal/assert/tag.h
@@ -230,7 +230,7 @@
         CRI_ASSERT_TYPE_TAG(Tag) *actual,                                   \
         CRI_ASSERT_TYPE_TAG(Tag) *expected);                                \
     CR_API int CRI_USER_TAG_ID(zero, Tag)(CRI_ASSERT_TYPE_TAG(Tag) *val);   \
-    CR_API char *CRI_USER_TAG_ID(tostr, Tag)(CRI_ASSERT_TYPE_TAG(Tag) *e);  \
+    CR_API char *CRI_USER_TAG_ID(tostr, Tag)(CRI_ASSERT_TYPE_TAG(Tag) *e);
 
 #ifndef __cplusplus
 # include <string.h>

--- a/include/criterion/internal/assert/tag.h
+++ b/include/criterion/internal/assert/tag.h
@@ -241,19 +241,47 @@ CRI_ASSERT_DECLARE_NATIVE_FN(chr, "c")
 CRI_ASSERT_DECLARE_NATIVE_FN(i8, PRId8)
 CRI_ASSERT_DECLARE_NATIVE_FN(i16, PRId16)
 CRI_ASSERT_DECLARE_NATIVE_FN(i32, PRId32)
-CRI_ASSERT_DECLARE_NATIVE_FN(i64, PRId64)
 CRI_ASSERT_DECLARE_NATIVE_FN(u8, PRIu8)
 CRI_ASSERT_DECLARE_NATIVE_FN(u16, PRIu16)
 CRI_ASSERT_DECLARE_NATIVE_FN(u32, PRIu32)
-CRI_ASSERT_DECLARE_NATIVE_FN(u64, PRIu64)
 CRI_ASSERT_DECLARE_NATIVE_FN(int, "d")
 CRI_ASSERT_DECLARE_NATIVE_FN(uint, "u")
 CRI_ASSERT_DECLARE_NATIVE_FN(long, "ld")
 CRI_ASSERT_DECLARE_NATIVE_FN(ulong, "lu")
-CRI_ASSERT_DECLARE_NATIVE_FN(llong, "lld")
-CRI_ASSERT_DECLARE_NATIVE_FN(ullong, "llu")
 CRI_ASSERT_DECLARE_STR_FN(str, "", "s")
 CRI_ASSERT_DECLARE_STR_FN(wcs, "L", "ls")
+
+#ifdef _MSC_VER
+CRI_ASSERT_DECLARE_NATIVE_FN(llong, "I64d")
+CRI_ASSERT_DECLARE_NATIVE_FN(ullong, "I64u")
+#else
+CRI_ASSERT_DECLARE_NATIVE_FN(llong, "lld")
+CRI_ASSERT_DECLARE_NATIVE_FN(ullong, "llu")
+#endif
+
+#ifdef _MSC_VER
+# ifdef _WIN64
+#  define CRI_PRIxPTR "I64x"
+# else
+#  define CRI_PRIxPTR "lx"
+# endif
+CRI_ASSERT_DECLARE_NATIVE_FN(i64, "I64d")
+CRI_ASSERT_DECLARE_NATIVE_FN(u64, "I64u")
+#elif defined(__MINGW32__)
+# if __WORDSIZE == 64
+#  define CRI_PRI64_PREFIX "l"
+#  define CRI_PRIxPTR "lx"
+# else
+#  define CRI_PRI64_PREFIX "ll"
+#  define CRI_PRIxPTR "llx"
+# endif
+CRI_ASSERT_DECLARE_NATIVE_FN(i64, CRI_PRI64_PREFIX "d")
+CRI_ASSERT_DECLARE_NATIVE_FN(u64, CRI_PRI64_PREFIX "u")
+#else
+# define CRI_PRIxPTR PRIxPTR
+CRI_ASSERT_DECLARE_NATIVE_FN(i64, PRId64)
+CRI_ASSERT_DECLARE_NATIVE_FN(u64, PRIu64)
+#endif
 
 CRI_ASSERT_DECLARE_NATIVE_CMP_FN(iptr)
 CRI_ASSERT_DECLARE_NATIVE_CMP_FN(uptr)
@@ -266,21 +294,21 @@ static inline char *CRI_USER_TAG_ID(tostr, iptr)(intptr_t *e)
         absptr = -absptr;
 
     char *str = NULL;
-    cr_asprintf(&str, "%s0x%" PRIxPTR, *e < 0 ? "-" : "", absptr);
+    cr_asprintf(&str, "%s0x%" CRI_PRIxPTR, *e < 0 ? "-" : "", absptr);
     return str;
 }
 
 static inline char *CRI_USER_TAG_ID(tostr, uptr)(uintptr_t *e)
 {
     char *str = NULL;
-    cr_asprintf(&str, "0x%" PRIxPTR, *e);
+    cr_asprintf(&str, "0x%" CRI_PRIxPTR, *e);
     return str;
 }
 
 static inline char *CRI_USER_TAG_ID(tostr, ptr)(void **e)
 {
     char *str = NULL;
-    cr_asprintf(&str, "0x%" PRIxPTR, (uintptr_t) *e);
+    cr_asprintf(&str, "0x%" CRI_PRIxPTR, (uintptr_t) *e);
     return str;
 }
 
@@ -325,11 +353,7 @@ CRI_ASSERT_DECLARE_NATIVE_FN(ldbl, "." CRI_DBL_DIG "g")
 CRI_ASSERT_DECLARE_NATIVE_FN(ldbl, "." CRI_LDBL_DIG "Lg")
 #endif
 
-# ifdef _WIN32
-CRI_ASSERT_DECLARE_NATIVE_FN(sz, "Iu")
-# else
-CRI_ASSERT_DECLARE_NATIVE_FN(sz, "zu")
-# endif
+CRI_ASSERT_DECLARE_NATIVE_FN(sz, CRI_PRIuSIZE)
 #endif
 
 #if defined (_WIN32)

--- a/include/criterion/internal/assert/tostr.h
+++ b/include/criterion/internal/assert/tostr.h
@@ -252,8 +252,8 @@ std::wstring cri_val_escape(const wchar_t (&s)[N])
         size_t cri_off = 0;                                                             \
         size_t cri_sz = 0;                                                              \
         cri_fmt_bprintf(&(Str), &cri_off, &cri_sz, "("                                  \
-                CR_STR(CRI_ASSERT_TYPE_TAG(Tag)) "["                                    \
-                CR_SIZE_T_FORMAT "]) {\n", CRI_ASSERT_TYPE_TAG_ARRLEN(Tag));            \
+                CR_STR(CRI_ASSERT_TYPE_TAG(Tag)) "[%" CRI_PRIuSIZE "]) {\n",            \
+                    CRI_ASSERT_TYPE_TAG_ARRLEN(Tag));                                   \
                                                                                         \
         for (size_t cri_i = 0; cri_i < cri_size; ++cri_i) {                             \
             char *cri_repr      = CRI_USER_TAG_ID(tostr, Tag)(&(Arr)[cri_i]);           \
@@ -262,7 +262,7 @@ std::wstring cri_val_escape(const wchar_t (&s)[N])
                                                                                         \
             if (cri_line) {                                                             \
                 cri_fmt_bprintf(&(Str), &cri_off, &cri_sz,                              \
-                        "\t[" CR_SIZE_T_FORMAT "] = %s", cri_i, cri_line);              \
+                        "\t[%" CRI_PRIuSIZE "] = %s", cri_i, cri_line);                 \
                                                                                         \
                 while ((cri_line = cri_strtok_r(NULL, "\n", &cri_saveptr))) {           \
                     cri_fmt_bprintf(&(Str), &cri_off, &cri_sz, "\n\t%s", cri_line);     \

--- a/include/criterion/internal/common.h
+++ b/include/criterion/internal/common.h
@@ -93,10 +93,10 @@
 # define CR_INLINE    inline
 #endif
 
-#ifdef _WIN32
-# define CR_SIZE_T_FORMAT    "%Iu"
+#if defined(_MSC_VER) && _MSC_VER < 1900
+# define CRI_PRIuSIZE    "Iu"
 #else
-# define CR_SIZE_T_FORMAT    "%zu"
+# define CRI_PRIuSIZE    "zu"
 #endif
 
 #ifdef __GNUC__

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -205,7 +205,7 @@ static void process_client_message_impl(struct server_ctx *sctx, struct client_c
 struct client_ctx *process_client_message(struct server_ctx *ctx, const criterion_protocol_msg *msg)
 {
     if (msg->version != PROTOCOL_V1) {
-        handler_error(ctx, "%s", "", "Received message using invalid protocol version number '%" PRIi32 "'.", msg->version);
+        handler_error(ctx, "%s", "", "Received message using invalid protocol version number '%" PRId32 "'.", msg->version);
         return NULL;
     }
 
@@ -216,7 +216,7 @@ struct client_ctx *process_client_message(struct server_ctx *ctx, const criterio
             if (k != kh_end(ctx->subprocesses))
                 client = &kh_value(ctx->subprocesses, k);
             else
-                handler_error(ctx, "%s", "", "Received message identified by a PID '%" PRIi64 "' "
+                handler_error(ctx, "%s", "", "Received message identified by a PID '%" PRId64 "' "
                         "that is not a child process.", msg->id.pid);
         } break;
         case criterion_protocol_msg_uid_tag: {

--- a/src/entry/params.c
+++ b/src/entry/params.c
@@ -136,7 +136,7 @@ int list_tests(void)
         if (!tests)
             continue;
 
-        printf("%s: " CR_SIZE_T_FORMAT " test%s\n",
+        printf("%s: %" CRI_PRIuSIZE " test%s\n",
                 s->suite.name,
                 tests,
                 tests == 1 ? "" : "s");

--- a/src/io/json.c
+++ b/src/io/json.c
@@ -34,10 +34,10 @@
 #include "config.h"
 #include "common.h"
 
-#define JSON_TEST_TEMPLATE_BEGIN                        \
-    "        {\n"                                       \
-    "          \"name\": \"%s\",\n"                     \
-    "          \"assertions\": " CR_SIZE_T_FORMAT ",\n" \
+#define JSON_TEST_TEMPLATE_BEGIN                     \
+    "        {\n"                                    \
+    "          \"name\": \"%s\",\n"                  \
+    "          \"assertions\": %" CRI_PRIuSIZE ",\n" \
     "          \"status\": \"%s\""
 
 #define JSON_TEST_TEMPLATE_END \
@@ -79,13 +79,13 @@
 #define JSON_TEST_LIST_TEMPLATE_END \
     "      ]\n"
 
-#define JSON_TESTSUITE_TEMPLATE_BEGIN            \
-    "    {\n"                                    \
-    "      \"name\": \"%s\",\n"                  \
-    "      \"passed\": " CR_SIZE_T_FORMAT ",\n"  \
-    "      \"failed\": " CR_SIZE_T_FORMAT ",\n"  \
-    "      \"errored\": " CR_SIZE_T_FORMAT ",\n" \
-    "      \"skipped\": " CR_SIZE_T_FORMAT ",\n"
+#define JSON_TESTSUITE_TEMPLATE_BEGIN         \
+    "    {\n"                                 \
+    "      \"name\": \"%s\",\n"               \
+    "      \"passed\": %" CRI_PRIuSIZE ",\n"  \
+    "      \"failed\": %" CRI_PRIuSIZE ",\n"  \
+    "      \"errored\": %" CRI_PRIuSIZE ",\n" \
+    "      \"skipped\": %" CRI_PRIuSIZE ",\n"
 
 #define JSON_TESTSUITE_TEMPLATE_END \
     "    }"
@@ -99,10 +99,10 @@
 #define JSON_BASE_TEMPLATE_BEGIN              \
     "{\n"                                     \
     "  \"id\": \"Criterion " VERSION "\",\n"  \
-    "  \"passed\": " CR_SIZE_T_FORMAT ",\n"   \
-    "  \"failed\": " CR_SIZE_T_FORMAT ",\n"   \
-    "  \"errored\": " CR_SIZE_T_FORMAT ",\n"  \
-    "  \"skipped\": " CR_SIZE_T_FORMAT ",\n"  \
+    "  \"passed\": %" CRI_PRIuSIZE ",\n"      \
+    "  \"failed\": %" CRI_PRIuSIZE ",\n"      \
+    "  \"errored\": %" CRI_PRIuSIZE ",\n"     \
+    "  \"skipped\": %" CRI_PRIuSIZE ",\n"     \
 
 #define JSON_BASE_TEMPLATE_END \
     "}\n"

--- a/src/io/tap.c
+++ b/src/io/tap.c
@@ -34,17 +34,13 @@
 
 static void print_prelude(FILE *f, struct criterion_global_stats *stats)
 {
-    fprintf(f, "TAP version 13\n1.."
-            CR_SIZE_T_FORMAT
-            "\n", stats->nb_tests);
+    fprintf(f, "TAP version 13\n1..%" CRI_PRIuSIZE "\n", stats->nb_tests);
     fprintf(f, "# Criterion %s\n", VERSION);
 }
 
 static void print_pre_suite(FILE *f, struct criterion_suite_stats *stats)
 {
-    fprintf(f, "#\n# Running "
-            CR_SIZE_T_FORMAT
-            " tests from %s\n",
+    fprintf(f, "#\n# Running %" CRI_PRIuSIZE " tests from %s\n",
             stats->nb_tests,
             stats->suite->name);
 }
@@ -66,7 +62,7 @@ static void print_test_normal(FILE *f, struct criterion_test_stats *stats)
     if (stats->test_status == CR_STATUS_FAILED) {
         fprintf(f, "  ---\n");
 
-        fprintf(f, "  assertions: " CR_SIZE_T_FORMAT "\n",
+        fprintf(f, "  assertions: %" CRI_PRIuSIZE "\n",
                 (size_t) (stats->passed_asserts + stats->failed_asserts));
         fprintf(f, "  failures:\n");
         for (struct criterion_assert_stats *asrt = stats->asserts; asrt; asrt = asrt->next) {

--- a/src/io/xml.c
+++ b/src/io/xml.c
@@ -37,10 +37,10 @@
 
 #define TESTSUITES_PROPERTIES            \
     "name=\"Criterion Tests\" "          \
-    "tests=\"" CR_SIZE_T_FORMAT "\" "    \
-    "failures=\"" CR_SIZE_T_FORMAT "\" " \
-    "errors=\"" CR_SIZE_T_FORMAT "\" "   \
-    "disabled=\"" CR_SIZE_T_FORMAT "\""
+    "tests=\"%" CRI_PRIuSIZE "\" "    \
+    "failures=\"%" CRI_PRIuSIZE "\" " \
+    "errors=\"%" CRI_PRIuSIZE "\" "   \
+    "disabled=\"%" CRI_PRIuSIZE "\""
 
 #define XML_BASE_TEMPLATE_BEGIN                             \
     "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"          \
@@ -52,11 +52,11 @@
 
 #define TESTSUITE_PROPERTIES             \
     "name=\"%s\" "                       \
-    "tests=\"" CR_SIZE_T_FORMAT "\" "    \
-    "failures=\"" CR_SIZE_T_FORMAT "\" " \
-    "errors=\"" CR_SIZE_T_FORMAT "\" "   \
-    "disabled=\"" CR_SIZE_T_FORMAT "\" " \
-    "skipped=\"" CR_SIZE_T_FORMAT "\" "  \
+    "tests=\"%" CRI_PRIuSIZE "\" "    \
+    "failures=\"%" CRI_PRIuSIZE "\" " \
+    "errors=\"%" CRI_PRIuSIZE "\" "   \
+    "disabled=\"%" CRI_PRIuSIZE "\" " \
+    "skipped=\"%" CRI_PRIuSIZE "\" "  \
     "time=\"%.3f\""
 
 #define XML_TESTSUITE_TEMPLATE_BEGIN \
@@ -67,7 +67,7 @@
 
 #define TEST_PROPERTIES                    \
     "name=\"%s\" "                         \
-    "assertions=\"" CR_SIZE_T_FORMAT "\" " \
+    "assertions=\"%" CRI_PRIuSIZE "\" " \
     "status=\"%s\" "                       \
     "time=\"%.3f\""
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -68,6 +68,10 @@ configure_file(input         : 'config.h.in',
 
 libcriterion = both_libraries('criterion', sources,
 	include_directories: [criterion_includedir],
+	# extra args that we don't want to pass to tests, samples, etc
+	c_args: [
+		'-D__USE_MINGW_ANSI_STDIO',
+	],
 	version: '3.1.0',
 	dependencies: deps,
 	install: true,


### PR DESCRIPTION
MinGW uses by default the windows CRT for printf, but can be convinced
to use its own ANSI-compatible printf implementation by defining the
__USE_MINGW_ANSI_STDIO macro.

This fix is two-fold: first, we use the "I64" specifier prefix instead of "ll"
for the long long type modifier if we're using MSVC.

Then, since cr_asprintf uses printf and is compiled in libcriterion.so,
we have to make a choice on which printf to use for our users.
Naturally, we prefer the standards-compliant one.

Fixes #322.