### PR TITLE
ci: Fixed paths to isdir.py and dependencies when building as meson subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,7 @@ prefix    = get_option('prefix')
 localedir = get_option('localedir')
 
 # Helper scripts
-auxdir  = join_paths(meson.source_root(), 'ci')
+auxdir  = join_paths(meson.current_source_dir(), 'ci')
 isdir   = join_paths(auxdir, 'isdir.py')
 
 python3 = find_program('python3')

--- a/src/meson.build
+++ b/src/meson.build
@@ -57,9 +57,9 @@ sources = files(
 	'string/i18n.c',
 	'string/xxd.c',
 
-	'../dependencies/nanopb/pb_common.c',
-	'../dependencies/nanopb/pb_encode.c',
-	'../dependencies/nanopb/pb_decode.c',
+	meson.current_source_dir() + '/../dependencies/nanopb/pb_common.c',
+	meson.current_source_dir() + '/../dependencies/nanopb/pb_encode.c',
+	meson.current_source_dir() + '/../dependencies/nanopb/pb_decode.c',
 )
 
 configure_file(input         : 'config.h.in',


### PR DESCRIPTION
Fixes #327 