### PR TITLE
meson: Add options to not-build samples and tests.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -225,5 +225,11 @@ deps += [
 
 subdir('include')
 subdir('src')
-subdir('samples')
-subdir('test')
+
+if get_option('samples')
+	subdir('samples')
+endif
+
+if get_option('tests')
+	subdir('test')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,5 +1,6 @@
 option('tests', type: 'boolean', value: true)
 option('dev',   type: 'boolean', value: false)
+option('samples', type: 'boolean', value: true)
 
 option('cxx-support', type: 'feature', value: 'auto')
 option('i18n',        type: 'feature', value: 'auto')


### PR DESCRIPTION
tl;dr same as https://github.com/Snaipe/BoxFort/pull/27 but for Criterion.

When using Criterion as a subproject, meson test runs Criiterion's tests. I believe a typical developer developing their super project wants to run only own tests, not dependencies' ones.

This PR adds -Dsamples and -Dtests options to enable/disable, like this:

```sh
meson setup -Dsamples=false -Dtests=false build && cd build && meson test
# Or as a subproject
meson setup -Dcriterion:samples=false -Dcriterion:tests=false build && cd build && meson test
```