### PR TITLE
meson: fix 'theories' option to be actually disablable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.sw[op]
 .*.sw[op]
 build
+subprojects/boxfort
+subprojects/libgit2
+subprojects/nanomsg

--- a/meson.build
+++ b/meson.build
@@ -193,8 +193,6 @@ endif
 boxfort = dependency('boxfort', fallback: ['boxfort', 'boxfort'])
 libffi = dependency('libffi', required: get_option('theories'), fallback: ['libffi', 'ffi_dep'])
 
-config.set('ENABLE_THEORIES', libffi.found())
-
 # optional platform-dependent standard libs
 librt = cc.find_library('rt', required: false)
 libm  = cc.find_library('m',  required: false)

--- a/samples/meson.build
+++ b/samples/meson.build
@@ -11,9 +11,11 @@ samples = [
 	'simple.c',
 	'skip.c',
 	'suites.c',
-	'theories.c',
 	'timeout.c',
 ]
+if get_option('theories').enabled()
+	samples += ['theories.c']
+endif
 
 if has_cxx
 	samples += [
@@ -28,9 +30,11 @@ if has_cxx
 		'signal.cc',
 		'simple.cc',
 		'skip.cc',
-		'suites.cc',
-		'theories.cc',
+		'suites.cc'
 	]
+	if get_option('theories').enabled()
+		samples += ['theories.cc']
+	endif
 endif
 
 foreach sample : samples

--- a/src/meson.build
+++ b/src/meson.build
@@ -25,7 +25,6 @@ sources = files(
 	'core/runner_coroutine.c',
 	'core/stats.c',
 	'core/test.c',
-	'core/theories.c',
 
 	'csptr/array.c',
 	'csptr/mman.c',
@@ -61,6 +60,10 @@ sources = files(
 	meson.current_source_dir() + '/../dependencies/nanopb/pb_encode.c',
 	meson.current_source_dir() + '/../dependencies/nanopb/pb_decode.c',
 )
+
+if get_option('theories').enabled()
+	sources += files('core/theories.c')
+endif
 
 configure_file(input         : 'config.h.in',
                output        : 'config.h',

--- a/test/full/meson.build
+++ b/test/full/meson.build
@@ -4,9 +4,11 @@ full_tests = [
 	'flood.c',
 	'long-messages.c',
 	'other-crashes.c',
-	'theories_regression.c',
 	'with-time.c',
 ]
+if get_option('theories').enabled()
+	full_tests += ['theories_regression.c']
+endif
 
 if has_cxx
 	full_tests += [
@@ -14,9 +16,11 @@ if has_cxx
 		'exit.cc',
 		'failmessages.cc',
 		'long-messages.cc',
-		'other-crashes.cc',
-		'theories_regression.cc',
+		'other-crashes.cc'
 	]
+	if get_option('theories').enabled()
+		full_tests += ['theories_regression.cc']
+	endif
 endif
 
 foreach tst : full_tests

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -1,8 +1,10 @@
 unit_test_sources = files(
-	'asprintf.c',
 	'ordered-set.c',
 	'path.c',
 )
+if get_option('theories').enabled()
+    unit_test_sources += files('asprintf.c')
+endif
 
 #if has_cxx
 #	unit_test_sources += files(


### PR DESCRIPTION
With `meson -Dtheories=disabled` not only `libffi` is not used as a dependency, but also `src/core/theories.c` and theories samples and tests are not being built.

My use case:
- I try to build a minimal `Dockerfile` for my CI-ing my software. I don't need `ffi`;
- I use Criterion for tests :) ;
- I don't use theories.