### PR TITLE
meson: add option to disable libgit2

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -181,7 +181,7 @@ if not nanopb.found()
 endif
 
 libgit2 = dependency('libgit2', required: false)
-if not libgit2.found()
+if not libgit2.found() and get_option('diffs').enabled()
 	libgit2_proj = cmake.subproject('libgit2',
 		cmake_options: [
 			'-DBUILD_SHARED_LIBS=OFF',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -5,6 +5,7 @@ option('samples', type: 'boolean', value: true)
 option('cxx-support', type: 'feature', value: 'auto')
 option('i18n',        type: 'feature', value: 'auto')
 option('theories',    type: 'feature', value: 'enabled')
+option('diffs',       type: 'feature', value: 'enabled')
 
 # Platform-specific workarounds
 option('mingw-define-off_t', type: 'boolean', value: false)

--- a/src/meson.build
+++ b/src/meson.build
@@ -49,7 +49,6 @@ sources = files(
 	'protocol/protocol.c',
 
 	'string/brz.c',
-	'string/diff.c',
 	'string/extglobmatch.c',
 	'string/fmt.c',
 	'string/i18n.c',
@@ -70,6 +69,12 @@ if must_regenerate_pb
 	sources += gen_pb
 else
 	sources += 'protocol/criterion.pb.c'
+endif
+
+if get_option('diffs').enabled()
+	sources += files('string/diff.c')
+else
+	sources += files('string/diff-stubs.c')
 endif
 
 if get_option('theories').enabled()

--- a/src/string/diff-stubs.c
+++ b/src/string/diff-stubs.c
@@ -1,0 +1,35 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright © 2020 Franklin "Snaipe" Mathieu <http://snai.pe/>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "diff.h"
+
+void cri_diff_init(void)
+{
+}
+
+int cri_diff_buffer_to_buffer(const struct cri_diff_buffer *b1,
+        const struct cri_diff_buffer *b2, struct cri_diff_buffer *out)
+{
+    return 0;
+}


### PR DESCRIPTION
Added the meson option to disable dependency of `libgit2`.

My use case is:
- I try to produce a minimal `Dockerfile` for my software and I am on very early stages. In the end it will be used in CI;
- I use Criterion :) ;
- `libgit2` is a big library which adds both to `docker build` time and taking space, and all it brings is to diff strings in 2 places (`src/core/assert.c` + `src/log/normal.c` via `cri_diff_buffer_to_buffer`).
- Right now it is good enough for me to not-have beautiful git-diffs. I still get the failed assertion anyway and I can get proper git-diff running the test locally. :)