### PR TITLE
redirect: fix double free due to fclose multiple times the same fd

### DIFF
--- a/samples/redirect.c
+++ b/samples/redirect.c
@@ -18,10 +18,16 @@ Test(redirect, test_outputs, .init = redirect_all_std) {
 
     cr_assert_stdout_eq_str("foo");
 
+    fprintf(stdout, "second call");
+    fflush(stdout);
+
+    cr_assert_stdout_eq_str("second call");
+
     fprintf(stderr, "bar");
     fflush(stderr);
 
     cr_assert_stderr_eq_str("bar");
+
 }
 
 /* Testing general I/O with sample command-line rot13 */

--- a/src/io/file.c
+++ b/src/io/file.c
@@ -78,7 +78,7 @@ int cr_stdout_match_str(const char *ref)
     FILE *f = cr_get_redirected_stdout();
     int res = cr_file_match_str(f, ref);
 
-    fclose(f);
+    //fclose(f);
     return res;
 }
 
@@ -96,6 +96,6 @@ int cr_stderr_match_str(const char *ref)
     FILE *f = cr_get_redirected_stderr();
     int res = cr_file_match_str(f, ref);
 
-    fclose(f);
+    //fclose(f);
     return res;
 }


### PR DESCRIPTION
fixed with a `PIPE_DUP` flag
#314 

`fclose` close the associated `fd` when called. In order to avoid an invalid `read/free` afterwards, when calling `pipe_in` with the same `fd`, the argument `PIPE_DUP` is passed as opt to the `pipe_in` function.

See also: #382