### PR TITLE
Simplify autotools example

### DIFF
--- a/dev/autotools/Makefile.am
+++ b/dev/autotools/Makefile.am
@@ -8,7 +8,8 @@ LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
 check_PROGRAMS = criterion_tests
 
 criterion_tests_SOURCES = simple.c
-criterion_tests_LDFLAGS = -lcriterion
+criterion_tests_CFLAGS =  $(CRITERION_CFLAGS)
+criterion_tests_LDFLAGS =  $(CRITERION_LIBS)
 
 TESTS = criterion_tests
 EXTRA_DIST = $(TESTS)

--- a/dev/autotools/Makefile.am
+++ b/dev/autotools/Makefile.am
@@ -1,9 +1,11 @@
-# use the provided wrapper script to output things properly
-LOG_COMPILER = $(top_srcdir)/build-aux/criterion-tap-test
-
 # use the TAP log driver
 TEST_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
             $(top_srcdir)/build-aux/tap-driver.sh
+
+ # Setup Criterion TAP output using ENV
+ AM_TESTS_ENVIRONMENT = \
+    CRITERION_OUTPUTS='tap:-'; \
+    export CRITERION_OUTPUTS;
 
 check_PROGRAMS = criterion_tests
 

--- a/dev/autotools/Makefile.am
+++ b/dev/autotools/Makefile.am
@@ -14,4 +14,3 @@ criterion_tests_CFLAGS =  $(CRITERION_CFLAGS)
 criterion_tests_LDFLAGS =  $(CRITERION_LIBS)
 
 TESTS = criterion_tests
-EXTRA_DIST = $(TESTS)

--- a/dev/autotools/Makefile.am
+++ b/dev/autotools/Makefile.am
@@ -2,7 +2,7 @@
 LOG_COMPILER = $(top_srcdir)/build-aux/criterion-tap-test
 
 # use the TAP log driver
-LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
+TEST_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
             $(top_srcdir)/build-aux/tap-driver.sh
 
 check_PROGRAMS = criterion_tests

--- a/dev/autotools/README.md
+++ b/dev/autotools/README.md
@@ -6,20 +6,13 @@ This is a project skeleton that uses criterion tests with the TAP test driver.
 
 Be sure to do the following to get similar setups to work:
 
-1. copy `tap-driver.sh` from your automake installation ([`autogen.sh:4-7`](autogen.sh#L4-L7)).
-2. create a wrapper script that contains the following ([`autogen.sh:12-15`](autogen.sh#L12-L15)):
-
-  ```bash
-  #!/bin/sh
-  $1 -Otap:- --always-succeed 2>&1 >/dev/null
-  ```
-
-3. Check for criterion ([`configure.ac:5-7`](configure.ac#L5-L7)).
-4. Check for awk ([`configure.ac:9`](configure.ac#L9)).
-5. Check for `tap-driver.sh` ([`configure.ac:14`](configure.ac#L14)).
-6. Set `LOG_COMPILER` to the path of the wrapper script created at step 2 ([`Makefile.am:2`](Makefile.am#L2)).
-7. Set `LOG_DRIVER` to a command running `tap-driver.sh` with our found awk ([`Makefile.am:5-6`](Makefile.am#L5-L6)).
-8. Register your test programs ([`Makefile.am:8-14`](Makefile.am#L8-L14)).
+1. Check for `Criterion` ([`configure.ac:5-7`](configure.ac#L5-L7)).
+1. Substitute the flags needed to link against `Criterion` ([`configure.ac:9-10`](configure.ac#L9-L10)).
+1. Check for `awk` ([`configure.ac:12`](configure.ac#L12)).
+1. Check for `tap-driver.sh` ([`configure.ac:17`](configure.ac#L17)).
+1. Set `LOG_DRIVER` to a command running `tap-driver.sh` with our found awk ([`Makefile.am:2-3`](Makefile.am#L2-L3)).
+1. Set `AM_TESTS_ENVIRONMENT` to ensure that `Criterion` outputs its results using TAP ([`Makefile.am:6-8`](Makefile.am#L6-L8)).
+1. Register your test program ([`Makefile.am:10-17`](Makefile.am#L10-L17)).
 
 ## Running the tests
 

--- a/dev/autotools/autogen.sh
+++ b/dev/autotools/autogen.sh
@@ -1,18 +1,3 @@
 #!/bin/sh -e
 
-# copy TAP driver into build-aux
-automake_ver=$(automake --version | \grep -E -o '[0-9]\.[0-9]{2}')
-automake_dir=$(dirname $(which automake))/..
-
-mkdir -p build-aux
-cp -f $automake_dir/share/automake-$automake_ver/tap-driver.sh build-aux
-
-# create criterion TAP log compiler
-# this is necessary to print TAP (and only TAP) on the standard output,
-# and always exit with 0 to let the TAP driver handle errors itself.
-echo >build-aux/criterion-tap-test """#!/bin/sh
-\$1 -Otap:- --always-succeed
-"""
-chmod +x build-aux/criterion-tap-test
-
 autoreconf -vi

--- a/dev/autotools/configure.ac
+++ b/dev/autotools/configure.ac
@@ -6,6 +6,9 @@ PKG_CHECK_MODULES([CRITERION], [criterion], [], [
   AC_MSG_ERROR([unable to find Criterion])
 ])
 
+AC_SUBST([CRITERION_CFLAGS])
+AC_SUBST([CRITERION_LIBS])
+
 AC_PROG_AWK
 AC_PROG_CC
 

--- a/dev/autotools/configure.ac
+++ b/dev/autotools/configure.ac
@@ -2,9 +2,9 @@ AC_INIT([Criterion Autotools Tests], [1.0], [your@email.com])
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror])
 
-AC_CHECK_LIB([criterion], [criterion_initialize], [], [
+PKG_CHECK_MODULES([CRITERION], [criterion], [], [
   AC_MSG_ERROR([unable to find Criterion])
-], [])
+])
 
 AC_PROG_AWK
 AC_PROG_CC


### PR DESCRIPTION
I have been helping students setup a big project using Autotools and Criterion at my school. Having used both of them together before, I was surprised to see that your example setup is way more complicated than what I had arrived at by reading the documentation.

I have both simplified the setup to use environment variables to setup TAP output (making the use of a wrapper shell script redundant), and made the example stricter in terms of good practices regarding the use of Autotools.