### PR TITLE
docs: fix simple typo, chacacter -> character

### DIFF
--- a/src/string/brz.c
+++ b/src/string/brz.c
@@ -165,7 +165,7 @@ glob *glob_blank()
 }
 
 /*
- * single chacacter
+ * single character
  * nullable for ? and *
  * derivative: Empty string if chr == c
  *             Empty set otherwise


### PR DESCRIPTION
There is a small typo in src/string/brz.c.

Should read `character` rather than `chacacter`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md