### PR TITLE
Fix C++20 compatibility: Removed feature used

### DIFF
--- a/include/criterion/alloc.h
+++ b/include/criterion/alloc.h
@@ -268,7 +268,7 @@ struct allocator {
     inline pointer address(reference r) { return &r; }
     inline const_pointer address(const_reference r) { return &r; }
 
-    inline pointer allocate(size_type cnt, typename std::allocator<void>::const_pointer = 0)
+    inline pointer allocate(size_type cnt, const std::allocator<void>::value_type * = 0)
     {
         return reinterpret_cast<pointer>(cr_malloc(cnt * sizeof (T)));
     }


### PR DESCRIPTION
The `std::allocator<T>` type in the C++ standard library does not declare
the `const_pointer` associated type anymore, as per the update of the
C++ standard.

This fix replaces its usage with a normal constant pointer:

```diff
-typename std::allocator<void>::const_pointer
+const std::allocator<void>::value_type *
```