### PR TITLE
fix: compile error on macOS Monterey

### DIFF
--- a/src/compat/section-mach-o.c
+++ b/src/compat/section-mach-o.c
@@ -27,6 +27,7 @@
 #include <mach-o/getsect.h>
 #include <mach-o/loader.h>
 
+#include "err.h"
 #include "section.h"
 
 #ifdef __LP64__


### PR DESCRIPTION
Criterion/src/compat/section-mach-o.c:98:9: error: implicit declaration of function 'cr_panic' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        cr_panic("Could not allocate cri_section");
        ^
1 error generated.

Fixes #392