### PR TITLE
Fix non-deterministic crash on aarch64, support Apple silicon

### DIFF
--- a/subprojects/boxfort.wrap
+++ b/subprojects/boxfort.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = boxfort
 url = https://github.com/Snaipe/BoxFort.git
-revision = 38c49b14189fb66f0a97ea892d93ff4f948e9e00
+revision = cec0db7ab13c51d0baa01e2680b0edee2f7d317a


### PR DESCRIPTION
Depends on Snaipe/BoxFort#33
Fixes #312
Fixes #376