### PR TITLE
Docs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <h1><img src="doc/criterion-title.png" height="96" alt="Criterion Logo" /></h1>
 
-[![Build Status](https://api.cirrus-ci.com/github/Snaipe/Criterion.svg)](https://cirrus-ci.com/github/Snaipe/Criterion) 
-[![Coverage Status](https://img.shields.io/codecov/c/github/Snaipe/Criterion/bleeding.svg)](https://codecov.io/github/Snaipe/Criterion?branch=bleeding) 
-[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/Snaipe/Criterion/blob/master/LICENSE) 
-[![Version](https://img.shields.io/github/release/Snaipe/Criterion.svg?label=version)](https://github.com/Snaipe/Criterion/releases/latest) 
+[![Build Status](https://api.cirrus-ci.com/github/Snaipe/Criterion.svg)](https://cirrus-ci.com/github/Snaipe/Criterion)
+[![Coverage Status](https://img.shields.io/codecov/c/github/Snaipe/Criterion/bleeding.svg)](https://codecov.io/github/Snaipe/Criterion?branch=bleeding)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/Snaipe/Criterion/blob/master/LICENSE)
+[![Version](https://img.shields.io/github/release/Snaipe/Criterion.svg?label=version)](https://github.com/Snaipe/Criterion/releases/latest)
 
 A dead-simple, yet extensible, C and C++ unit testing framework.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ the user would have with other frameworks:
     $ sudo apt-get install criterion-dev
     ```
 * Arch Linux ([AUR](https://aur.archlinux.org/packages/criterion/)): `pacaur -S criterion`
-* macOS: `brew install snaipe/soft/criterion`
+* macOS: `brew install mranno/tap/criterion`
 
 ### Binary archives
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ the user would have with other frameworks:
 * [x] Supports parameterized tests and theories.
 * [x] Progress and statistics can be followed in real time with report hooks.
 * [x] TAP output format can be enabled with an option.
-* [x] Runs on Linux, FreeBSD, Mac OS X, and Windows (Compiling with MinGW GCC and Visual Studio 2015+).
+* [x] Runs on Linux, FreeBSD, macOS, and Windows (Compiling with MinGW GCC and Visual Studio 2015+).
 
 ## Downloads
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Criterion is built with the following projects:
 
 * [boxfort](https://github.com/diacritic/BoxFort)
 * [debugbreak](https://github.com/scottt/debugbreak)
-* [dyncall](http://www.dyncall.org/)
+* [libffi](https://sourceware.org/libffi/)
 * [klib](http://attractivechaos.github.io/klib/)
 * [libcsptr](https://github.com/Snaipe/libcsptr)
 * [nanomsg](http://nanomsg.org/)

--- a/README.md
+++ b/README.md
@@ -38,15 +38,15 @@ the user would have with other frameworks:
 
 ### Packages
 
-* Mac OS X: `brew install snaipe/soft/criterion`
-* [AUR](https://aur.archlinux.org/packages/criterion/): `pacaur -S criterion`
-* Ubuntu/Debian:
+* Ubuntu (>=21.04) / Debian (>=11): `apt-get install libcriterion-dev`, on older versions:
 
     ```bash
     $ sudo add-apt-repository ppa:snaipewastaken/ppa
     $ sudo apt-get update
     $ sudo apt-get install criterion-dev
     ```
+* Arch Linux ([AUR](https://aur.archlinux.org/packages/criterion/)): `pacaur -S criterion`
+* macOS: `brew install snaipe/soft/criterion`
 
 ### Binary archives
 

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -30,4 +30,4 @@ Features
 * Supports parameterized tests and theories.
 * Progress and statistics can be followed in real time with report hooks.
 * TAP output format can be enabled with an option.
-* Runs on Linux, FreeBSD, Mac OS X, and Windows (Compiling with MinGW GCC and Visual Studio 2015+).
+* Runs on Linux, FreeBSD, macOS, and Windows (Compiling with MinGW GCC and Visual Studio 2015+).

--- a/doc/setup.rst
+++ b/doc/setup.rst
@@ -15,7 +15,19 @@ The following compilers are supported to compile both the library and the tests:
 Building from source
 --------------------
 
-First, clone this repository:
+First, install dependencies:
+
+* C/C++ compiler
+* Meson, Ninja
+* CMake (for subprojects)
+* pkg-config
+* libffi (libffi-dev)
+* libgit2 (libgit2-dev)
+
+Other runtime dependencies will be bundled if they are not available on the
+system (BoxFort, debugbreak, klib, nanomsg, nanopb).
+
+Clone this repository:
 
 .. code-block:: bash
 

--- a/doc/setup.rst
+++ b/doc/setup.rst
@@ -4,7 +4,7 @@ Setup
 Prerequisites
 -------------
 
-The library is supported on Linux, OS X, FreeBSD, and Windows.
+The library is supported on Linux, macOS, FreeBSD, and Windows.
 
 The following compilers are supported to compile both the library and the tests:
 
@@ -28,7 +28,7 @@ Then, run the following commands to build Criterion:
     $ meson build
     $ ninja -C build
 
-Installing the library and language files (Linux, OS X, FreeBSD)
+Installing the library and language files (Linux, macOS, FreeBSD)
 ----------------------------------------------------------------
 
 Run with an elevated shell:


### PR DESCRIPTION
- rename OS X to macOS
- update Ubuntu/Debian installation steps (official .deb packages: https://repology.org/project/criterion/versions)
- document that libffi (and other build dependencies) needs to be installed when compiling from source
- replace dyncall reference with libffi
- replace old macOS brew repo with `mranno/tap/criterion`, which has binary packages compiled from the current `bleeding` branch.

Resolves #372
Fixes #391