### PR TITLE
api,float: fix ULP comparison when threshold is 0, and comparing infinities with epsilons.

### DIFF
--- a/include/criterion/internal/assert/ieee.h
+++ b/include/criterion/internal/assert/ieee.h
@@ -111,7 +111,7 @@ CRI_DEFINE_IEEE_ULP_EQ(ldbl, l)
 /* Epsilon specifiers */
 
 #define CRI_EPSILON_EQ(Lhs, Rhs, Eps) \
-    ((Rhs) - (Lhs) <= (Eps) && (Lhs) - (Rhs) <= (Eps))
+    (((Rhs) == (Lhs)) || ((Rhs) - (Lhs) <= (Eps) && (Lhs) - (Rhs) <= (Eps)))
 
 #define CRI_EPSILON_NE(Lhs, Rhs, Eps) !CRI_EPSILON_EQ(Lhs, Rhs, Eps)
 

--- a/include/criterion/internal/assert/ieee.h
+++ b/include/criterion/internal/assert/ieee.h
@@ -74,7 +74,7 @@ bool ieee_eq(Float &a, Float &b, size_t ulp)
         CRI_ASSERT_TYPE_TAG(Tag) b, size_t ulp)                               \
     {                                                                         \
         if (ulp == 0)                                                         \
-            return 0;                                                         \
+            return a == b;                                                    \
         a = nextafter ## Suffix(a, b);                                        \
         return a == b ? 1 : CRI_USER_TAG_ID(ieee_ulp_eq, Tag)(a, b, ulp - 1); \
     }

--- a/samples/asserts.c
+++ b/samples/asserts.c
@@ -67,6 +67,12 @@ Test(asserts, native) {
 Test(asserts, float) {
     cr_assert(ieee_ulp_eq(flt, 0.1 * 0.1, 0.01, 3));
     cr_assert(epsilon_eq(flt, 0.1 * 0.1, 0.01, 0.01));
+
+    /* Floating-point infinities still work with epsilons, ulps, and direct
+       equality */
+    cr_assert(ieee_ulp_eq(flt, INFINITY, INFINITY, 0));
+    cr_assert(epsilon_eq(flt, INFINITY, INFINITY, 0));
+    cr_assert(eq(flt, INFINITY, INFINITY));
 }
 
 struct dummy_struct {


### PR DESCRIPTION
Fixes #293.