### PR TITLE
misc,cram: fix cram patch not working from ninja test

### DIFF
--- a/test/cram/meson.build
+++ b/test/cram/meson.build
@@ -18,6 +18,7 @@ if sh.found() and cram.found()
 
 	test('cram tests', cram,
 			timeout: 240,
-			args: ['--shell=' + sh.path(), meson.current_source_dir()],
+			workdir: join_paths(meson.current_source_dir(), '..', '..'),
+			args: ['--shell=' + sh.path(), 'test/cram'],
 			env: env)
 endif


### PR DESCRIPTION
This restores the ability to patch cram failures via `CRAM=-iy ninja test`,
which broke when switching to meson: because the test directory passed
to cram was an absolute path, the patch program would also get fed absolute
path, which in turn declined to do anything for safety reasons.

This commit forces the cram test to execute with the working directory
set to the project root, passing `test/cram` as path instead.
Interestingly, changing the workdir to test/cram and then using `.` as
test path did not work.