### PR TITLE
Automated release workflow

### DIFF
--- a/.github/workflows/ff-bleeding.yml
+++ b/.github/workflows/ff-bleeding.yml
@@ -1,0 +1,39 @@
+name: Fast-forward bleeding
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
+env:
+  FF_ISSUE_TITLE: "No-FF: bleeding is behind master"
+  GITHUB_TOKEN: ${{ github.token }}
+
+jobs:
+  fast-forward-bleeding:
+    name: Fast-forward bleeding
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Criterion
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Fast-forward bleeding
+        run: |
+          git checkout bleeding
+          if ! git merge --ff-only --no-edit master; then
+            issue_opened="$(gh issue list --state open --jq ".[] | select(.title == \"${FF_ISSUE_TITLE}\")" --json title)"
+            if [ -z "${issue_opened}" ]; then
+              gh issue create --title "${FF_ISSUE_TITLE}" --body ""
+            fi
+            exit 1
+          fi
+
+          git push origin bleeding

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,163 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+
+env:
+  RELEASE_BRANCH: master
+  RELEASE_CANDIDATE_TAG_PATTERN: ^v[0-9]+.[0-9]+.[0-9]+-rc
+  RELEASE_SIGNING_KEY_ID: 75B0 21D9 64AD 8693 24CD  B74D DDD7 BCCD 44BB 9A9D
+  GITHUB_TOKEN: ${{ github.token }}
+
+jobs:
+  release-tag-verification:
+    name: "Release tag verification"
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Criterion
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+      - name: Release tag verification
+        run: |
+          gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys "${RELEASE_SIGNING_KEY_ID}"
+          if ! git tag --verify "$GITHUB_REF_NAME" > git-verify-tag.log 2>&1; then
+            gh issue create --title "$GITHUB_REF_NAME tag verification failure" --body-file git-verify-tag.log
+            exit 1
+          fi
+
+  tarball:
+    name: "Source tarball"
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.detect-version.outputs.version }}
+
+    steps:
+      - name: Check out Criterion
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Install dist dependencies
+        run: sudo apt-get update && sudo apt-get install -y meson
+
+      - name: Detect version
+        id: detect-version
+        run: |
+          if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
+            version="$GITHUB_REF_NAME"
+          else
+            version="$(git describe --long)"
+            if [[ ! "${version}" =~ ${RELEASE_CANDIDATE_TAG_PATTERN} ]]; then
+              printf "Pre-release requires an annotated tag with '-rc' suffix (actual: %s)\n" "${version}"
+              exit 1
+            fi
+          fi
+          version="${version:1}"
+          echo "${version}"
+          echo "::set-output name=version::${version}"
+
+      - name: Create source tarball
+        env:
+          version: ${{ steps.detect-version.outputs.version }}
+        run: |
+          meson rewrite kwargs set project / version "${version}"
+          git commit --allow-empty -a -m "release: version bump to v${version}"
+          meson setup -Dc_std=gnu11 --wrap-mode forcefallback build
+          meson dist -C build --include-subprojects --formats xztar
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: source-tarball
+          path: build/meson-dist/criterion-*.tar.xz
+          if-no-files-found: error
+
+  binaries:
+    name: "Binaries"
+    runs-on: ubuntu-latest
+    # glibc v2.17 builder
+    container: centos:7
+    needs: [tarball]
+    env:
+      version: ${{ needs.tarball.outputs.version }}
+
+    steps:
+      - name: Install build dependencies
+        run: |
+          yum update -y
+          yum install -y epel-release centos-release-scl
+          yum install -y python3-pip ninja-build cmake3 pkgconfig gcc gcc-c++
+          python3 -m pip install meson
+          ln -s /usr/bin/cmake3 /usr/bin/cmake
+
+      - name: Download source tarball
+        uses: actions/download-artifact@v2
+        with:
+          name: source-tarball
+
+      - name: Extract source tarball
+        run: |
+          tar -xf "criterion-${version}.tar.xz" && rm "criterion-${version}.tar.xz"
+
+      - name: Build Criterion
+        run: |
+          meson setup -Dc_std=gnu11 --prefix /usr/local --libdir lib --buildtype plain \
+            --force-fallback-for libffi --wrap-mode nodownload \
+            build "criterion-${version}"
+          meson compile -C build
+          meson install -C build --skip-subprojects --destdir "$(realpath .)/binaries/criterion-${version}"
+
+      - name: Create binary tarball
+        run: |
+          tar --create --xz --file "binaries/criterion-${version}-linux-x86_64.tar.xz" \
+            --exclude='*.a' --transform="s,^\.,criterion-${version}," \
+            -C "binaries/criterion-${version}/usr/local" .
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: binaries
+          path: binaries/criterion-*.tar.xz
+          if-no-files-found: error
+
+  release:
+    name: "Release"
+    runs-on: ubuntu-latest
+    needs: [tarball, binaries]
+    env:
+      version: ${{ needs.tarball.outputs.version }}
+
+    steps:
+      - name: Check out Criterion
+        uses: actions/checkout@v2
+
+      - name: Download source tarball
+        uses: actions/download-artifact@v2
+        with:
+          name: source-tarball
+
+      - name: Download binaries
+        uses: actions/download-artifact@v2
+        with:
+          name: binaries
+
+      - name: Create pre-release
+        if: github.ref_type == 'branch'
+        run: gh release create --prerelease --target "${RELEASE_BRANCH}" --title "v${version}" "v${version}" criterion-*.tar.xz
+
+      - name: Create release draft
+        if: github.ref_type == 'tag'
+        run: gh release create --draft --target "${RELEASE_BRANCH}" --title "v${version}" "v${version}" criterion-*.tar.xz

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('criterion', 'c',
 		meson_version   : '>= 0.51.0',
 		license         : 'MIT',
-		version         : '2.3.3',
+		version         : '2.4.0',
 		default_options : ['c_std=c11', 'cpp_std=c++11', 'warning_level=2'])
 
 abi_version = '3.2.0'

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ project('criterion', 'c',
 		version         : '2.3.3',
 		default_options : ['c_std=c11', 'cpp_std=c++11', 'warning_level=2'])
 
-abi_version = '3.1.0'
+abi_version = '3.2.0'
 
 # standard install directories
 prefix    = get_option('prefix')

--- a/meson.build
+++ b/meson.build
@@ -4,6 +4,8 @@ project('criterion', 'c',
 		version         : '2.3.3',
 		default_options : ['c_std=c11', 'cpp_std=c++11', 'warning_level=2'])
 
+abi_version = '3.1.0'
+
 # standard install directories
 prefix    = get_option('prefix')
 localedir = get_option('localedir')

--- a/meson.build
+++ b/meson.build
@@ -206,8 +206,9 @@ if not libgit2.found() and get_option('diffs').enabled()
 	libgit2 = libgit2_proj.dependency('git2')
 endif
 
-boxfort = dependency('boxfort', fallback: ['boxfort', 'boxfort'])
-libffi = dependency('libffi', required: get_option('theories'), fallback: ['libffi', 'ffi_dep'])
+boxfort = dependency('boxfort', fallback: ['boxfort', 'boxfort'], default_options: ['default_library=static'])
+libffi = dependency('libffi', required: get_option('theories'), fallback: ['libffi', 'ffi_dep'],
+					default_options: ['default_library=static'])
 
 # optional platform-dependent standard libs
 librt = cc.find_library('rt', required: false)

--- a/src/meson.build
+++ b/src/meson.build
@@ -91,7 +91,7 @@ libcriterion = both_libraries('criterion', sources,
 	c_args: [
 		'-D__USE_MINGW_ANSI_STDIO',
 	],
-	version: '3.1.0',
+	version: abi_version,
 	dependencies: deps,
 	install: true,
 	link_args: cc.get_supported_link_arguments([


### PR DESCRIPTION
This PR tries to automate the last few steps of the Criterion release process.

When a commit is pushed to the master branch or a version tag is created, the release workflow starts automatically.
The workflow can be restarted manually on either a tag or a branch if needed.

The release draft workflow creates the source tarball (which includes all subprojects), builds Criterion from the tarball, and creates binary packages.

![c2](https://user-images.githubusercontent.com/3130044/150004612-69ec6b1a-e33a-45fa-994f-1e9177fd2639.png)

Binary packages are created within a CentOS 7 container. This sounds terrible, but it ensures that Criterion is built with an older glibc version (v2.17) so that it will work on a wide variety of Linux distros.

The source tarball and the binaries then will be attached to the release on the Releases page.

In case new commits are pushed to the master branch, a pre-release will be published automatically using `git describe --long` for the name of the pre-release (this creates unsigned lightweight tags).

![c4](https://user-images.githubusercontent.com/3130044/150004703-2f35906e-514f-4257-a5ab-1b351465cc6c.png)

When the workflow is triggered by a new version tag (vX.Y.Z), a final release DRAFT will be made. This needs to be reviewed and published manually.

![c1](https://user-images.githubusercontent.com/3130044/150004658-7d340002-188f-4c8a-bed8-6e40fff4fd61.png)

The workflow verifies the release tag as well, it opens an issue to warn maintainers about unsigned or lightweight release tags.

![c3](https://user-images.githubusercontent.com/3130044/150004744-a8da312c-22f9-4a1f-be0a-8e2a62f717fe.png)

----

Another workflow tries to fast-forward bleeding. If that's not possible, an issue will be raised.