### PR TITLE
Fix debugging on macOS and add fallback debug method

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/attractivechaos/klib.git
 [submodule "dependencies/debugbreak"]
 	path = dependencies/debugbreak
-	url = https://github.com/scottt/debugbreak
+	url = https://github.com/MrAnno/debugbreak.git

--- a/ChangeLog
+++ b/ChangeLog
@@ -55,11 +55,14 @@
     * Fix: fixed crash when passing an empty string to cr_log_info (Ersikan).
     * Fix: fixed compilation errors on macOS (Kare Nuorteva, László Várady).
     * Fix: fixed --debug flag aborting runner with gdbserver >= 8.3.
+    * Fix: fixed gdb stepping issue with '--debug' on macOS (Apple silicon).
     * Misc: various documentation fixes (Oleksii Vilchanskyi, Sam Zaydel, Karim
-      Dridi, Florent Poinsard, Tim Gates, László Várady).
+      Dridi, Florent Poinsard, Tim Gates, László Várady, Japroz Saini).
     * Misc: various updates to dependencies (László Várady).
     * Misc: various build system fixes (Tomasz Sieprawski, László Várady).
     * Misc: various fixes to the autotools example (Bruno Belany).
+    * Misc: from now on, --debug will fall back to the idle method in case no
+      debugger can be found.
 
     The full git changelog may be accessed with `git log v2.3.3..v2.4.0`.
 

--- a/doc/debug.rst
+++ b/doc/debug.rst
@@ -63,6 +63,27 @@ and run the test with ``continue``
 
 To use a different port use ``--debug --debug-transport=<protocol>:<port>``
 
+Debugging on macOS
+------------------
+
+macOS has its own LLVM-based debugger called ``debugserver``.
+Make sure the debugger server is available in your PATH (by default, it is not).
+
+You will probably need sudo privileges as well:
+
+.. code-block:: bash
+
+    $ sudo ./test --debug
+    Listening to port 1234 for a connection from *...
+
+In another terminal, connect to the debug session:
+
+.. code-block:: bash
+
+    $ sudo lldb ./test
+    (lldb) gdb-remote localhost:1234
+
+
 Debugging with an unsupported debugger
 --------------------------------------
 

--- a/subprojects/boxfort.wrap
+++ b/subprojects/boxfort.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = boxfort
 url = https://github.com/Snaipe/BoxFort.git
-revision = 46cfaebead74bd1d2898afb66a06ec6badce4326
+revision = fe06439edd619ef574cf897195f0976bb60e4781


### PR DESCRIPTION
- `--debug` now uses the official macOS `debugserver` by default (if it's on `PATH`)
- `--debug` will fall back to the `idle` method in case no debugger can be found

Depends on Snaipe/BoxFort#36
Fixes #420