### PR TITLE
Workaround for unimplemented mincore() on WSL 1

### DIFF
--- a/subprojects/boxfort.wrap
+++ b/subprojects/boxfort.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = boxfort
 url = https://github.com/Snaipe/BoxFort.git
-revision = fe06439edd619ef574cf897195f0976bb60e4781
+revision = a26074c5cc900fabc85424253f0f64e3b9c661c3


### PR DESCRIPTION
Fixes #424
See also #364

Depends on Snaipe/BoxFort#38

Note: I've added `[skip actions]` to the commit message just in case we want to skip creating another release candidate.

IMHO no changelog entry is needed, `Fix: worked around msync not properly working on WSL and causing the runner to break` covers this PR as well.