### PR TITLE
added hint to run ldconfig

### DIFF
--- a/doc/setup.rst
+++ b/doc/setup.rst
@@ -49,6 +49,12 @@ Run with an elevated shell:
 
     $ ninja -C build install
 
+On Linux systems, update the dynamic linker runtime bindings:
+
+.. code-block:: bash
+
+    $ ldconfig
+
 Usage
 -----
 


### PR DESCRIPTION
Updated setup documentation to avoid runtime errors right after compiling and installing Criterion on Linux.