### PR TITLE
Fix user-facing compiler warnings with `-Wconversion`

### DIFF
--- a/include/criterion/internal/assert/op.h
+++ b/include/criterion/internal/assert/op.h
@@ -316,7 +316,7 @@
                 ) ")";                                                      \
             size_t cri_paramidx = 0;                                        \
             CRITERION_APPLY(CRI_ASSERT_IT_MKNODE_AUTO, , __VA_ARGS__)       \
-            cri_tmpn.pass = cri_cond_un;                                    \
+            cri_tmpn.pass = !!cri_cond_un;                                  \
             cri_prevnode = cri_assert_node_add(cri_node, &cri_tmpn);        \
         }                                                                   \
     } while (0)
@@ -348,7 +348,7 @@
                 ) ")";                                                      \
             size_t cri_paramidx = 0;                                        \
             CRITERION_APPLY(CRI_ASSERT_IT_MKNODE, Tag, __VA_ARGS__)         \
-            cri_tmpn.pass = cri_cond_un;                                    \
+            cri_tmpn.pass = !!cri_cond_un;                                  \
             cri_prevnode = cri_assert_node_add(cri_node, &cri_tmpn);        \
         }                                                                   \
     } while (0)
@@ -375,8 +375,8 @@
             cri_tmpn.dynrepr = 1;                                                   \
             cri_paramidx = 0;                                                       \
             CRITERION_APPLY(CRI_ASSERT_IT_MKNODE_SUBSCRIPT, Tag, __VA_ARGS__)       \
-            cri_tmpn.pass = CRI_ASSERT_OP_APPLY(Op,                                 \
-                    Tag CRITERION_APPLY(CRI_ASSERT_IT_SUNPACK, , __VA_ARGS__));     \
+            cri_tmpn.pass = !!(CRI_ASSERT_OP_APPLY(Op,                              \
+                    Tag CRITERION_APPLY(CRI_ASSERT_IT_SUNPACK, , __VA_ARGS__)));    \
             cri_prevnode = cri_assert_node_add(cri_node, &cri_tmpn);                \
             cri_node->pass = cri_node->pass && cri_tmpn.pass;                       \
         }                                                                           \

--- a/include/criterion/internal/assert/tag.h
+++ b/include/criterion/internal/assert/tag.h
@@ -289,7 +289,7 @@ CRI_ASSERT_DECLARE_NATIVE_CMP_FN(ptr)
 
 static inline char *CRI_USER_TAG_ID(tostr, iptr)(intptr_t *e)
 {
-    uintptr_t absptr = *e;
+    uintptr_t absptr = (uintptr_t) *e;
     if (absptr > (uintptr_t)INTPTR_MAX)
         absptr = -absptr;
 

--- a/include/criterion/internal/new_asserts.h
+++ b/include/criterion/internal/new_asserts.h
@@ -95,7 +95,7 @@
         if (cri_cond_un != cri_cond_expect) {                           \
             cri_assert_node_init(&cri_tmpn);                            \
             cri_tmpn.repr = CR_STR(Val);                                \
-            cri_tmpn.pass = cri_cond_un;                                \
+            cri_tmpn.pass = !!cri_cond_un;                              \
             cri_prevnode = cri_assert_node_add(cri_node, &cri_tmpn);    \
         }                                                               \
     } while (0)
@@ -124,7 +124,7 @@
         int cri_cond_def = 1, cri_cond_un;                                              \
         int cri_cond = cri_cond_def                                                     \
             CRITERION_APPLY(CRI_ASSERT_SPECIFIER_ALL_INDIRECT, cri_cond, __VA_ARGS__);  \
-        cri_node->pass = cri_cond;                                                      \
+        cri_node->pass = !!cri_cond;                                                    \
         *cri_pass = *cri_pass && cri_cond;                                              \
         cri_prevnode = cri_node;                                                        \
     } while (0); cri_pass = cri_pass_orig
@@ -146,7 +146,7 @@
         int cri_cond_def = 1, cri_cond_un;                                              \
         int cri_cond = cri_cond_def                                                     \
             CRITERION_APPLY(CRI_ASSERT_SPECIFIER_NONE_INDIRECT, cri_cond, __VA_ARGS__); \
-        cri_node->pass = cri_cond;                                                      \
+        cri_node->pass = !!cri_cond;                                                    \
         *cri_pass = *cri_pass && cri_cond;                                              \
         cri_prevnode = cri_node;                                                        \
     } while (0); cri_pass = cri_pass_orig
@@ -163,7 +163,7 @@
         int cri_cond_def = 0;                                                           \
         int cri_cond = cri_cond_def                                                     \
             CRITERION_APPLY(CRI_ASSERT_SPECIFIER_ANY_INDIRECT, cri_cond, __VA_ARGS__);  \
-        cri_node->pass = cri_cond;                                                      \
+        cri_node->pass = !!cri_cond;                                                    \
         *cri_pass = *cri_pass && cri_cond;                                              \
         cri_prevnode = cri_node;                                                        \
     } while (0); cri_pass = cri_pass_orig

--- a/src/capi/stream.c
+++ b/src/capi/stream.c
@@ -64,10 +64,12 @@ static int streams_eval_cmp(struct cr_stream *m1, struct cr_stream *m2)
         m1->cri_data->remaining = r1;
         m2->cri_data->remaining = r2;
 
-        cmp = r1 - r2;
-        if (!cmp) {
+        if (r1 == r2) {
             cmp = memcmp(m1->cri_data->buffer, m2->cri_data->buffer, r1);
+            continue;
         }
+
+        cmp = r1 < r2 ? -1 : 1;
     } while (r1 && !cmp);
 
     m1->cri_data->dirty = 1;

--- a/src/compat/processor.c
+++ b/src/compat/processor.c
@@ -47,7 +47,8 @@ size_t get_processor_count(void)
         count = 1;
     return (size_t) count;
 #elif defined (__linux__)
-    return sysconf(_SC_NPROCESSORS_ONLN);
+    long count = sysconf(_SC_NPROCESSORS_ONLN);
+    return count < 1 ? 1 : (size_t) count;
 #else
 # error System not supported
 #endif

--- a/src/compat/section-elf.c
+++ b/src/compat/section-elf.c
@@ -47,7 +47,7 @@ static size_t page_size(void) {
         page_size = 0x1000;
         long v = sysconf(_SC_PAGESIZE);
         if (v > 0) {
-            page_size = v;
+            page_size = (size_t) v;
         }
     }
     return page_size;
@@ -96,11 +96,13 @@ static int open_self(void)
         }
         return -1;
     }
-    if ((size_t) rc == PATH_MAX) {
+
+    size_t fullpath_len = (size_t) rc;
+    if (fullpath_len == PATH_MAX) {
         errno = ENAMETOOLONG;
         return -1;
     }
-    memset(fullpath + rc, 0, PATH_MAX - rc);
+    memset(fullpath + fullpath_len, 0, PATH_MAX - fullpath_len);
 
 do_open:
     return open(fullpath, O_RDONLY);
@@ -184,7 +186,7 @@ static const void *map_shdr(int fd, const ElfW (Shdr) *shdr,
     size_t shdr_map_len = shdr->sh_size + (shdr->sh_offset - shdr_map_off);
 
     const uint8_t *shdr_map = mmap(NULL, shdr_map_len,
-                    PROT_READ, MAP_PRIVATE, fd, shdr_map_off);
+                    PROT_READ, MAP_PRIVATE, fd, (off_t) shdr_map_off);
 
     if (shdr_map == MAP_FAILED)
         return NULL;
@@ -250,7 +252,7 @@ static int section_getaddr(struct dl_phdr_info *info,
 
     if (get_section_data(&mod, ctx->sectname, (void *) info->dlpi_addr, &sect)) {
         if (ctx->i >= ctx->size) {
-            ctx->size *= 1.5f;
+            ctx->size = (size_t) (ctx->size * 1.5);
             ctx->sect = realloc(ctx->sect, sizeof (struct cri_section) * (ctx->size + 1));
             if (!ctx->sect)
                 cr_panic("Could not allocate cri_section");


### PR DESCRIPTION
Fixes #446.

There are ~160 warnings in Criterion related to implicit conversions.
I haven't fixed all of them as most seemed to be false positives.
This PR focuses on user-facing ones and a few others.