### PR TITLE
Add FreeBSD package information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ the user would have with other frameworks:
 **Arch Linux** ([AUR][aur]) | `pacaur -S criterion`
 **macOS** | `brew install criterion`
 **Nix** | `nix-env -iA nixpkgs.criterion`
+**FreeBSD** | `pkg install criterion`
 
 If you'd like to see Criterion included in your favorite distribution, please reach out to their package maintainers team.
 


### PR DESCRIPTION
FreeBSD package is now available.

Port [commit information](https://cgit.freebsd.org/ports/commit/?id=c32decee33ce9db095fb2b77e4ece07c5ec50f59).
FreshPorts [information](https://www.freshports.org/devel/criterion/).