### PR TITLE
fix(redirect): Don't close stdout, stderr file handles when using multiple asserts

### DIFF
--- a/src/io/file.c
+++ b/src/io/file.c
@@ -69,7 +69,6 @@ int cr_stdout_match_file(FILE *ref)
     FILE *f = cr_get_redirected_stdout();
     int res = cr_file_match_file(f, ref);
 
-    fclose(f);
     return res;
 }
 
@@ -78,7 +77,6 @@ int cr_stdout_match_str(const char *ref)
     FILE *f = cr_get_redirected_stdout();
     int res = cr_file_match_str(f, ref);
 
-    fclose(f);
     return res;
 }
 
@@ -87,7 +85,6 @@ int cr_stderr_match_file(FILE *ref)
     FILE *f = cr_get_redirected_stderr();
     int res = cr_file_match_file(f, ref);
 
-    fclose(f);
     return res;
 }
 
@@ -96,6 +93,5 @@ int cr_stderr_match_str(const char *ref)
     FILE *f = cr_get_redirected_stderr();
     int res = cr_file_match_str(f, ref);
 
-    fclose(f);
     return res;
 }


### PR DESCRIPTION
<img width="272" alt="Screenshot 2022-10-11 at 23 08 32" src="https://user-images.githubusercontent.com/37590995/195198665-49db4a12-412c-4fe8-8736-5687e542b0f3.png">
<img width="524" alt="Screenshot 2022-10-11 at 23 08 20" src="https://user-images.githubusercontent.com/37590995/195198627-986cd264-6fb2-4c6a-8288-369746373b48.png">
