### PR TITLE
diff: fix crash in assert failure reporting when there is no diff

### DIFF
--- a/test/cram/asserts.t
+++ b/test/cram/asserts.t
@@ -27,7 +27,7 @@ Testing all assert messages
   [----] failmessages.c:214: Assertion Failed
   [----] failmessages.c:215: Assertion Failed
   [----]   eq(i32, 1, 1): 
-  [----]     diff: [-1-]{+1+}
+  [----]     @@@ <no difference -- this is a user bug in the object stringifier>
   [FAIL] message::compo
   [----] failmessages.c:165: Assertion Failed
   [----]   lt(i8, 1, 0): 
@@ -537,7 +537,7 @@ C++ equivalents
   [----] failmessages.cc:217: Assertion Failed
   [----] failmessages.cc:218: Assertion Failed
   [----]   eq(i32, 1, 1): 
-  [----]     diff: [-1-]{+1+}
+  [----]     @@@ <no difference -- this is a user bug in the object stringifier>
   [FAIL] message::compo
   [----] failmessages.cc:222: Assertion Failed
   [----]   throw(std::bad_alloc, throw std::invalid_argument("exception message")): 

--- a/test/cram/bugs.t
+++ b/test/cram/bugs.t
@@ -1,0 +1,13 @@
+https://github.com/Snaipe/Criterion/issues/463
+
+  $ bug463.c.bin
+  [----] bug463.c:16: Assertion Failed
+  [----]   eq(type(struct T1), (struct T1){}, (struct T1){}): 
+  [----]     @@@ <no message or difference -- this is a user bug in the object stringifier>
+  [FAIL] bug463::nl
+  [----] bug463.c:31: Assertion Failed
+  [----]   eq(type(struct T2), (struct T2){}, (struct T2){}): 
+  [----]     @@@ <no difference -- this is a user bug in the object stringifier>
+  [FAIL] bug463::nonl
+  [====] Synthesis: Tested: 2 | Passing: 0 | Failing: 2 | Crashing: 0 
+

--- a/test/full/bug463.c
+++ b/test/full/bug463.c
@@ -1,0 +1,32 @@
+#include <criterion/criterion.h>
+#include <criterion/new/assert.h>
+
+struct T1 {};
+
+int cr_user_T1_eq(struct T1 *a, struct T1 *b) { return 0; }
+
+char *cr_user_T1_tostr(struct T1 *d)
+{
+    char *out;
+    cr_asprintf(&out, "hello\n");
+    return out;
+}
+
+Test(bug463, nl) {
+    cr_assert(eq(type(struct T1), (struct T1){}, (struct T1){}));
+}
+
+struct T2 {};
+
+int cr_user_T2_eq(struct T2 *a, struct T2 *b) { return 0; }
+
+char *cr_user_T2_tostr(struct T2 *d)
+{
+    char *out;
+    cr_asprintf(&out, "hello");
+    return out;
+}
+
+Test(bug463, nonl) {
+    cr_assert(eq(type(struct T2), (struct T2){}, (struct T2){}));
+}

--- a/test/full/meson.build
+++ b/test/full/meson.build
@@ -5,6 +5,9 @@ full_tests = [
 	'long-messages.c',
 	'other-crashes.c',
 	'with-time.c',
+
+	# bug-specific programs
+	'bug463.c',
 ]
 
 if get_option('theories').enabled()


### PR DESCRIPTION
If the user-provided function to stringify an object is bugged and produces equal output for non-equal objects, thus producing an empty diff, Criterion would crash trying to access an unset parameter list.

This fixes the crash by checking that we do have expected values, and printing placeholder messages if we do not.

Fixes #463.