### PR TITLE
nanopb: fix incorrect arguments to protoc

### DIFF
--- a/src/protocol/gen-pb.py
+++ b/src/protocol/gen-pb.py
@@ -17,7 +17,7 @@ makedirs(build_dir, exist_ok=True)
 
 cmdline = [protoc_path, '--plugin=protoc-gen-nanopb=' + gen_path,
       '-I' + source_dir,
-      '--nanopb_out=' + '-f ' + options_file + ':' + build_dir,
+      '--nanopb_out=' + '-f' + options_file + ':' + build_dir,
       proto_file]
 
 sys.stderr.write(" ".join(cmdline) + "\n")


### PR DESCRIPTION
In gen-pb.py, we call protoc to compile our protobuf declarations with nanopb's generator plugin.  The issue is that we used a space between -f and the name of the option file, which causes the option file to not be found as the space is considered part of the filename.

If the option file is not found, all our unit tests crash on Debian testing, with nanopb 0.4.7.  Earlier versions of nanopb probably were not so picky about that space.

Signed-off-by: Balazs Scheidler <bazsi77@gmail.com>