### PR TITLE
core: fix deadlock in overloaded scenarios

### DIFF
--- a/src/core/client.c
+++ b/src/core/client.c
@@ -263,7 +263,7 @@ bool handle_birth(struct server_ctx *sctx, struct client_ctx *ctx, const criteri
     (void) sctx;
     (void) msg;
 
-    ctx->alive = true;
+    ctx->dead = false;
     return false;
 }
 
@@ -452,7 +452,7 @@ bool handle_death(struct server_ctx *sctx, struct client_ctx *ctx, const criteri
 {
     (void) sctx;
 
-    ctx->alive = false;
+    ctx->dead = true;
 
     const criterion_protocol_death *death = &msg->data.value.death;
     enum client_state curstate = ctx->state & (CS_MAX_CLIENT_STATES - 1);

--- a/src/core/client.h
+++ b/src/core/client.h
@@ -56,7 +56,7 @@ struct client_ctx {
     struct criterion_test extern_test;
 
     uint32_t state;
-    bool alive;
+    bool dead;
     struct criterion_global_stats *gstats;
     struct criterion_suite_stats *sstats;
     struct criterion_test_stats *tstats;

--- a/src/core/runner.c
+++ b/src/core/runner.c
@@ -297,7 +297,7 @@ static void run_tests_async(struct criterion_test_set *set,
         if (!cctx)
             continue;
 
-        if (!cctx->alive) {
+        if (cctx->dead) {
             if ((cctx->tstats->test_status == CR_STATUS_FAILED) && criterion_options.fail_fast)
                 cr_terminate(cctx->gstats);
 


### PR DESCRIPTION
Root cause: `client_ctx::alive` handling and BoxFort timeout conflict

To indicate that a client is dead, a death message has to be sent to the runner, and that message needs to be the very last message. This is done correctly.

The problem is `handle_birth()`, which sets the `alive` flag to true. Under rare circumstances (overloaded system), the `handle_birth()` action may never run due to the test timeout that occurs before sending out the birth message. This scenario leaves the `alive` flag on false, causing a deadlock:

```
-- thread 1
run_tests_async():
  while (read_message()):
    process_message()
    if not alive -> remove_client() -> destroy_client_context() -> bxf_wait() -> pthread_cond_wait()

-- thread 2
child_pump_fn():
  reap_child() -> death_callback() -> cr_send_to_runner() * 2 -> nn_recv()
  ...
  pthread_cond_broadcast(&instance->cond);
```

The death callback contains a `cr_send_to_runner()` invocation, which waits for the main message loop to send an ack, which will never happen.