### PR TITLE
Fix gt() and ge()

### DIFF
--- a/include/criterion/internal/assert/op.h
+++ b/include/criterion/internal/assert/op.h
@@ -158,8 +158,8 @@
 # define CRI_BINOP_T_NE(Tag, Actual, Ref) (CRI_BINOP_EQ_TAG(Tag, !, Actual, Ref))
 # define CRI_BINOP_T_LE(Tag, Actual, Ref) (CRI_BINOP_LT_TAG(Tag, , Actual, Ref) || CRI_BINOP_EQ_TAG(Tag, , Actual, Ref))
 # define CRI_BINOP_T_LT(Tag, Actual, Ref) (CRI_BINOP_LT_TAG(Tag, , Actual, Ref))
-# define CRI_BINOP_T_GE(Tag, Actual, Ref) (CRI_BINOP_LT_TAG(Tag, !, Actual, Ref) || CRI_BINOP_EQ_TAG(Tag, , Actual, Ref))
-# define CRI_BINOP_T_GT(Tag, Actual, Ref) (CRI_BINOP_LT_TAG(Tag, !, Actual, Ref))
+# define CRI_BINOP_T_GE(Tag, Actual, Ref) (CRI_BINOP_LT_TAG(Tag, !, Actual, Ref))
+# define CRI_BINOP_T_GT(Tag, Actual, Ref) (CRI_BINOP_LT_TAG(Tag, !, Actual, Ref) && CRI_BINOP_EQ_TAG(Tag, !, Actual, Ref))
 
 # define CRI_UNOP_ZERO(X)        !(X)
 # define CRI_UNOP_T_ZERO(Tag, X) CRI_USER_TAG_ID(zero, Tag)(&(X))

--- a/samples/asserts.c
+++ b/samples/asserts.c
@@ -62,6 +62,8 @@ Test(asserts, native) {
     cr_assert(gt(i32, 2, 1));
     cr_assert(ge(i32, 2, 1));
     cr_assert(ge(i32, 2, 2));
+
+    cr_assert(not(gt(i32, 0, 0)));
 }
 
 Test(asserts, float) {

--- a/samples/asserts.cc
+++ b/samples/asserts.cc
@@ -66,6 +66,8 @@ Test(asserts, native) {
     cr_assert(gt(2, 1));
     cr_assert(ge(2, 1));
     cr_assert(ge(2, 2));
+
+    cr_assert(not(gt(i32, 0, 0)));
 }
 
 Test(asserts, float) {

--- a/test/cram/asserts.t
+++ b/test/cram/asserts.t
@@ -1048,10 +1048,10 @@ Test C++ assertions:
   [----]   This assert runs
   [----]   
   [FAIL] asserts::base
-  [----] asserts.cc:168: Assertion Failed
+  [----] asserts.cc:170: Assertion Failed
   [----]   throw(std::runtime_error, {}): 
   [----]     message: <nothing was thrown>
-  [----] asserts.cc:170: Assertion Failed
+  [----] asserts.cc:172: Assertion Failed
   [----]   throw(std::bad_alloc, throw std::invalid_argument("some other message")): 
   [----]     message: "some other message"
   [FAIL] asserts::exception


### PR DESCRIPTION
Before this patch, the following assert was true:
`cr_assert(gt(int,0,0));`

Fixes #473