### PR TITLE
Fix memory leaks

### DIFF
--- a/include/criterion/internal/assert/tostr.h
+++ b/include/criterion/internal/assert/tostr.h
@@ -95,7 +95,7 @@ inline ostream &operator<<(ostream &s, const std::string &str)
     const char *cstr = str.c_str();
     char *fmt = cr_user_str_tostr(&cstr);
     s.base << fmt;
-    free(fmt);
+    std::free(fmt);
     return s;
 }
 
@@ -104,7 +104,7 @@ inline ostream &operator<<(ostream &s, const std::wstring &str)
     const wchar_t *cstr = str.c_str();
     char *fmt = cr_user_wcs_tostr(&cstr);
     s.base << fmt;
-    free(fmt);
+    std::free(fmt);
     return s;
 }
 

--- a/include/criterion/internal/new_asserts.h
+++ b/include/criterion/internal/new_asserts.h
@@ -86,6 +86,8 @@
             cri_assert_node_send(File, Line, &cri_root);                        \
             cri_assert_node_term(&cri_root);                                    \
             Fail();                                                             \
+        } else {                                                                \
+            cri_assert_node_term(&cri_root);                                    \
         }                                                                       \
     } while (0))
 

--- a/src/entry/params.c
+++ b/src/entry/params.c
@@ -363,6 +363,7 @@ CR_API int criterion_handle_args(int argc, char *argv[],
 
             quiet = must_be_quiet(path);
             criterion_add_output(provider, path);
+            free(s);
         }
         free(out);
     }
@@ -431,6 +432,7 @@ CR_API int criterion_handle_args(int argc, char *argv[],
 
                 quiet = must_be_quiet(path);
                 criterion_add_output(arg, path);
+                free(arg);
             } break;
             case 'w': criterion_options.wait_for_clients = true; break;
             case 's':

--- a/src/io/output.c
+++ b/src/io/output.c
@@ -73,6 +73,8 @@ int criterion_add_output(const char *provider, const char *path)
         k = kh_put(ht_path, outputs, provider, &absent);
         if (absent == -1)
             return -1;
+        if (absent != 0) /* The key does not exist yet and must be allocated */
+            kh_key(outputs, k) = strdup(provider);
 
         str_vec *vec = malloc(sizeof (str_vec));
         kv_init(*vec);
@@ -80,7 +82,7 @@ int criterion_add_output(const char *provider, const char *path)
     }
     str_vec *vec = kh_value(outputs, k);
 
-    kv_push(const char *, *vec, path);
+    kv_push(const char *, *vec, strdup(path));
     return 1;
 }
 
@@ -94,8 +96,11 @@ void criterion_free_output(void)
             if (!kh_exist(outputs, k))
                 continue;
             str_vec *vec = kh_value(outputs, k);
+            for (size_t i = 0; i < kv_size(*vec); ++i)
+                free((char *)kv_A(*vec, i));
             kv_destroy(*vec);
             free(vec);
+            free((char *)kh_key(outputs, k));
         }
         kh_destroy(ht_path, outputs);
     }

--- a/test/cram/asserts.t
+++ b/test/cram/asserts.t
@@ -21,15 +21,15 @@ Test C assertions:
 Testing all assert messages
 
   $ failmessages.c.bin
-  [----] failmessages.c:213: Assertion Failed
+  [----] failmessages.c:216: Assertion Failed
   [----]   eq(i32, 1, 0): 
   [----]     diff: [-1-]{+0+}
-  [----] failmessages.c:214: Assertion Failed
-  [----] failmessages.c:215: Assertion Failed
+  [----] failmessages.c:217: Assertion Failed
+  [----] failmessages.c:218: Assertion Failed
   [----]   eq(i32, 1, 1): 
   [----]     @@@ <no difference -- this is a user bug in the object stringifier>
   [FAIL] message::compo
-  [----] failmessages.c:165: Assertion Failed
+  [----] failmessages.c:168: Assertion Failed
   [----]   lt(i8, 1, 0): 
   [----]     actual: 1
   [----]     reference: 0
@@ -42,7 +42,7 @@ Testing all assert messages
   [----]   ge(i8, 0, 1): 
   [----]     actual: 0
   [----]     reference: 1
-  [----] failmessages.c:166: Assertion Failed
+  [----] failmessages.c:169: Assertion Failed
   [----]   lt(i16, 1, 0): 
   [----]     actual: 1
   [----]     reference: 0
@@ -55,7 +55,7 @@ Testing all assert messages
   [----]   ge(i16, 0, 1): 
   [----]     actual: 0
   [----]     reference: 1
-  [----] failmessages.c:167: Assertion Failed
+  [----] failmessages.c:170: Assertion Failed
   [----]   lt(i32, 1, 0): 
   [----]     actual: 1
   [----]     reference: 0
@@ -68,7 +68,7 @@ Testing all assert messages
   [----]   ge(i32, 0, 1): 
   [----]     actual: 0
   [----]     reference: 1
-  [----] failmessages.c:168: Assertion Failed
+  [----] failmessages.c:171: Assertion Failed
   [----]   lt(i64, 1, 0): 
   [----]     actual: 1
   [----]     reference: 0
@@ -81,7 +81,7 @@ Testing all assert messages
   [----]   ge(i64, 0, 1): 
   [----]     actual: 0
   [----]     reference: 1
-  [----] failmessages.c:169: Assertion Failed
+  [----] failmessages.c:172: Assertion Failed
   [----]   lt(u8, 1, 0): 
   [----]     actual: 1
   [----]     reference: 0
@@ -94,7 +94,7 @@ Testing all assert messages
   [----]   ge(u8, 0, 1): 
   [----]     actual: 0
   [----]     reference: 1
-  [----] failmessages.c:170: Assertion Failed
+  [----] failmessages.c:173: Assertion Failed
   [----]   lt(u16, 1, 0): 
   [----]     actual: 1
   [----]     reference: 0
@@ -107,7 +107,7 @@ Testing all assert messages
   [----]   ge(u16, 0, 1): 
   [----]     actual: 0
   [----]     reference: 1
-  [----] failmessages.c:171: Assertion Failed
+  [----] failmessages.c:174: Assertion Failed
   [----]   lt(u32, 1, 0): 
   [----]     actual: 1
   [----]     reference: 0
@@ -120,7 +120,7 @@ Testing all assert messages
   [----]   ge(u32, 0, 1): 
   [----]     actual: 0
   [----]     reference: 1
-  [----] failmessages.c:172: Assertion Failed
+  [----] failmessages.c:175: Assertion Failed
   [----]   lt(u64, 1, 0): 
   [----]     actual: 1
   [----]     reference: 0
@@ -133,7 +133,7 @@ Testing all assert messages
   [----]   ge(u64, 0, 1): 
   [----]     actual: 0
   [----]     reference: 1
-  [----] failmessages.c:173: Assertion Failed
+  [----] failmessages.c:176: Assertion Failed
   [----]   lt(iptr, 1, 0): 
   [----]     actual: 0x1
   [----]     reference: 0x0
@@ -146,7 +146,7 @@ Testing all assert messages
   [----]   ge(iptr, 0, 1): 
   [----]     actual: 0x0
   [----]     reference: 0x1
-  [----] failmessages.c:174: Assertion Failed
+  [----] failmessages.c:177: Assertion Failed
   [----]   lt(uptr, 1, 0): 
   [----]     actual: 0x1
   [----]     reference: 0x0
@@ -159,7 +159,7 @@ Testing all assert messages
   [----]   ge(uptr, 0, 1): 
   [----]     actual: 0x0
   [----]     reference: 0x1
-  [----] failmessages.c:175: Assertion Failed
+  [----] failmessages.c:178: Assertion Failed
   [----]   lt(flt, 1 / 3.f, 0): 
   [----]     actual: 0.333333343
   [----]     reference: 0
@@ -172,7 +172,7 @@ Testing all assert messages
   [----]   ge(flt, 0, 1 / 3.f): 
   [----]     actual: 0
   [----]     reference: 0.333333343
-  [----] failmessages.c:176: Assertion Failed
+  [----] failmessages.c:179: Assertion Failed
   [----]   lt(dbl, 1 / 3., 0): 
   [----]     actual: 0.33333333333333331
   [----]     reference: 0
@@ -185,7 +185,7 @@ Testing all assert messages
   [----]   ge(dbl, 0, 1 / 3.): 
   [----]     actual: 0
   [----]     reference: 0.33333333333333331
-  [----] failmessages.c:177: Assertion Failed
+  [----] failmessages.c:180: Assertion Failed
   [----]   lt(ldbl, 1 / 3.l, 0): 
   \[----\]     actual: 0\.3.* (re)
   [----]     reference: 0
@@ -198,7 +198,7 @@ Testing all assert messages
   [----]   ge(ldbl, 0, 1 / 3.l): 
   [----]     actual: 0
   \[----\]     reference: 0\.3.* (re)
-  [----] failmessages.c:180: Assertion Failed
+  [----] failmessages.c:183: Assertion Failed
   [----]   lt(ptr, (void *) 1, (void *) 0): 
   [----]     actual: 0x1
   [----]     reference: 0x0
@@ -211,7 +211,7 @@ Testing all assert messages
   [----]   ge(ptr, (void *) 0, (void *) 1): 
   [----]     actual: 0x0
   [----]     reference: 0x1
-  [----] failmessages.c:182: Assertion Failed
+  [----] failmessages.c:185: Assertion Failed
   [----]   lt(str, "cba", "abc"): 
   [----]     actual: "cba"
   [----]     reference: "abc"
@@ -224,7 +224,7 @@ Testing all assert messages
   [----]   ge(str, "abc", "cba"): 
   [----]     actual: "abc"
   [----]     reference: "cba"
-  [----] failmessages.c:183: Assertion Failed
+  [----] failmessages.c:186: Assertion Failed
   [----]   lt(str, "cba\ncba", "abc\nabc"): 
   [----]     actual: "cba\n"
   [----]       "cba"
@@ -245,7 +245,7 @@ Testing all assert messages
   [----]       "abc"
   [----]     reference: "cba\n"
   [----]       "cba"
-  [----] failmessages.c:185: Assertion Failed
+  [----] failmessages.c:188: Assertion Failed
   [----]   lt(wcs, L"cba", L"abc"): 
   [----]     actual: L"cba"
   [----]     reference: L"abc"
@@ -258,7 +258,7 @@ Testing all assert messages
   [----]   ge(wcs, L"abc", L"cba"): 
   [----]     actual: L"abc"
   [----]     reference: L"cba"
-  [----] failmessages.c:186: Assertion Failed
+  [----] failmessages.c:189: Assertion Failed
   [----]   lt(wcs, L"cba\ncba", L"abc\nabc"): 
   [----]     actual: L"cba\n"
   [----]       L"cba"
@@ -279,7 +279,7 @@ Testing all assert messages
   [----]       L"abc"
   [----]     reference: L"cba\n"
   [----]       L"cba"
-  [----] failmessages.c:206: Assertion Failed
+  [----] failmessages.c:209: Assertion Failed
   [----]   lt(stream, shi, slo): 
   [----]     actual: 00: 68656c6c 6f20776f 726c6400           hello world.    
   [----]       
@@ -301,8 +301,8 @@ Testing all assert messages
   [----]     reference: 00: 68656c6c 6f20776f 726c6400           hello world.    
   [----]       
   [FAIL] messages::cmp
-  [----] failmessages.c:219: Assertion Failed
-  [----] failmessages.c:220: Assertion Failed
+  [----] failmessages.c:222: Assertion Failed
+  [----] failmessages.c:223: Assertion Failed
   [----]   
   [----]   foo bar
   [----]   
@@ -437,9 +437,9 @@ Testing all assert messages
   [----]     +00: 646c726f 77206f6c 6c656800           dlrow olleh.    
   [----]      
   [FAIL] messages::eq
-  [----] failmessages.c:224: Assertion Failed
-  [----] failmessages.c:225: Assertion Failed
-  [----] failmessages.c:226: Assertion Failed
+  [----] failmessages.c:227: Assertion Failed
+  [----] failmessages.c:228: Assertion Failed
+  [----] failmessages.c:229: Assertion Failed
   [----]   
   [----]   "dquote" \\and\\ 'squote'\t\r (esc)
   [----]   <script>\x01. (esc)

--- a/test/cram/json.t
+++ b/test/cram/json.t
@@ -335,9 +335,9 @@ Testing --output=json
             "assertions": 3,
             "status": "FAILED",
             "messages": [
-              "failmessages.c:226: \"dquote\" \\and\\ 'squote'\t\r\n<script>\u0001.",
-              "failmessages.c:225: (no message)",
-              "failmessages.c:224: (no message)"
+              "failmessages.c:229: \"dquote\" \\and\\ 'squote'\t\r\n<script>\u0001.",
+              "failmessages.c:228: (no message)",
+              "failmessages.c:227: (no message)"
             ]
           },
           {
@@ -379,8 +379,8 @@ Testing --output=json
             "assertions": 2,
             "status": "FAILED",
             "messages": [
-              "failmessages.c:220: foo bar",
-              "failmessages.c:219: (no message)"
+              "failmessages.c:223: foo bar",
+              "failmessages.c:222: (no message)"
             ]
           },
           {
@@ -388,12 +388,15 @@ Testing --output=json
             "assertions": 19,
             "status": "FAILED",
             "messages": [
-              "failmessages.c:206: (no message)",
+              "failmessages.c:209: (no message)",
+              "failmessages.c:189: (no message)",
+              "failmessages.c:188: (no message)",
               "failmessages.c:186: (no message)",
               "failmessages.c:185: (no message)",
               "failmessages.c:183: (no message)",
-              "failmessages.c:182: (no message)",
               "failmessages.c:180: (no message)",
+              "failmessages.c:179: (no message)",
+              "failmessages.c:178: (no message)",
               "failmessages.c:177: (no message)",
               "failmessages.c:176: (no message)",
               "failmessages.c:175: (no message)",
@@ -403,10 +406,7 @@ Testing --output=json
               "failmessages.c:171: (no message)",
               "failmessages.c:170: (no message)",
               "failmessages.c:169: (no message)",
-              "failmessages.c:168: (no message)",
-              "failmessages.c:167: (no message)",
-              "failmessages.c:166: (no message)",
-              "failmessages.c:165: (no message)"
+              "failmessages.c:168: (no message)"
             ]
           }
         ]
@@ -423,9 +423,9 @@ Testing --output=json
             "assertions": 3,
             "status": "FAILED",
             "messages": [
-              "failmessages.c:215: (no message)",
-              "failmessages.c:214: (no message)",
-              "failmessages.c:213: (no message)"
+              "failmessages.c:218: (no message)",
+              "failmessages.c:217: (no message)",
+              "failmessages.c:216: (no message)"
             ]
           }
         ]

--- a/test/full/failmessages.c
+++ b/test/full/failmessages.c
@@ -150,6 +150,9 @@ Test(messages, eq) {
     cr_stream_init(&s2);
 
     cr_expect(eq(stream, s1, s2));
+
+    cr_stream_close(&s1);
+    cr_stream_close(&s2);
 }
 
 #define cmptest(Tag, Lo, Hi) \


### PR DESCRIPTION
Hello, this PR fixes some memory leaks so Criterion is now usable with Valgrind and AddressSanitizer.

The first commit fixes a memory leak in the handling of the `-O`/`--output` arguments. I've followed the Klib documentation https://attractivechaos.github.io/klib/#Khash%3A%20generic%20hash%20table to allocate and free the key for the hash table.

The second commit fixes a bug in the string conversion functions for C++. The strings are allocated using `std::malloc`, but were unallocated using `free`, which is aliased to `cr_free`, which couldn't handle unallocation properly.

The third commit fixes a memory leak in new asserts API. The allocated memory was not freed when the assert succeeds. I believe it also fixes issue #501.

Last commit adds missing `cr_stream_close` in the test `failmessages.c` that also lead to a memory leak.
