### PR TITLE
Use `nix-shell` instead of of `nix-env -iA`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ the user would have with other frameworks:
 **Gentoo** | `emerge -a dev-libs/criterion`
 **Arch Linux** ([AUR][aur]) | `pacaur -S criterion`
 **macOS** | `brew install criterion`
-**Nix** | `nix-env -iA nixpkgs.criterion`
+**Nix** | `nix-shell -p criterion`
 **FreeBSD** | `pkg install criterion`
 
 If you'd like to see Criterion included in your favorite distribution, please reach out to their package maintainers team.


### PR DESCRIPTION
`nix-env` for installing packages is a bad habit for nix/NixOS users and it is not recommended from the community as it doesn't mix well user configuration.nix / flake and/or home-manager. It also alters the system rather than providing a temporary package.

Since this is within the `download` section, it would make sense to use `nix-shell criterion` which will create a sub-shell with environment variable set to have criterion available.

I would have personally used `nix shell nixpkgs#criterion`, but the `nix` command is still an experimental feature, and isn't enabled by default