### PR TITLE
docs: Fix references to JSON/XML output format

### DIFF
--- a/doc/env.rst
+++ b/doc/env.rst
@@ -34,10 +34,10 @@ Command line arguments
   equivalent to ``--output=tap:FILE``.
 * ``--xml[=FILE]``: Writes JUnit4 XML report to FILE.
   No file or ``"-"`` means ``stderr`` and implies ``--quiet``. This option is
-  equivalent to ``--output=tap:FILE``.
+  equivalent to ``--output=xml:FILE``.
 * ``--json[=FILE]``: Writes a JSON report to FILE.
   No file or ``"-"`` means ``stderr`` and implies ``--quiet``. This option is
-  equivalent to ``--output=tap:FILE``.
+  equivalent to ``--output=json:FILE``.
 * ``--verbose[=level]``: Makes the output verbose. When provided with an integer,
   sets the verbosity level to that integer.
 * ``--crash``: Crash failing assertions rather than aborting (for debugging purposes)


### PR DESCRIPTION
JSON and XML outputs were using the TAP example as output. This PR fixes the reference to the appropriate example.