### PR TITLE
docs: Fix code block in setup doc

### DIFF
--- a/doc/setup.rst
+++ b/doc/setup.rst
@@ -36,6 +36,7 @@ Clone this repository:
 Then, run the following commands to build Criterion:
 
 .. code-block:: bash
+
     $ meson setup build
     $ meson compile -C build
 


### PR DESCRIPTION
This fixes [missing build commands](https://criterion.readthedocs.io/en/master/setup.html#building-from-source) in the Read the Docs documentation caused by a missing blank line before a code block.