### PR TITLE
docs: Add clarification on allowed types for theory data points.

### DIFF
--- a/include/criterion/theories.h
+++ b/include/criterion/theories.h
@@ -93,7 +93,8 @@ CR_END_C_API
  *  Defines a new set of data points.
  *
  *  @param Type The type of each data point in the set.
- *  @param ...  The data points in the set.
+ *              Must be a type whose size is less than or equal to sizeof(uint64_t).
+ *  @param ...  The data points in the set, listed as comma-separated values.
  */
 #define DataPoints(Type, ...)    CR_EXPAND(CR_TH_INTERNAL_DP(Type, __VA_ARGS__))
 


### PR DESCRIPTION
This PR adds a clarification into the docs for theory data points, specifying
that the size of the given type for a data point must not exceed
sizeof(uint64_t), as Criterion only supports types with sizes up to that limit.

Intended to solve issue #567
