### PR TITLE
Update deps and fix CI

### DIFF
--- a/subprojects/boxfort.wrap
+++ b/subprojects/boxfort.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = boxfort
 url = https://github.com/Snaipe/BoxFort.git
-revision = c91d7181734ab2fd6d1299e8aa927297f0ddb754
+revision = v0.1.5

--- a/subprojects/libgit2-cmake.wrap
+++ b/subprojects/libgit2-cmake.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory=libgit2
 url=https://github.com/libgit2/libgit2
-revision=v0.25.1
+revision=v1.9.1

--- a/subprojects/nanomsg-cmake.wrap
+++ b/subprojects/nanomsg-cmake.wrap
@@ -1,5 +1,5 @@
 [wrap-git]
 directory = nanomsg
 url = https://github.com/nanomsg/nanomsg
-revision = 1.2
+revision = 1.2.1
 depth = 1

--- a/subprojects/nanopb-cmake.wrap
+++ b/subprojects/nanopb-cmake.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = nanopb
 url = https://github.com/nanopb/nanopb
-revision = nanopb-0.4.7
+revision = nanopb-0.4.9.1


### PR DESCRIPTION
Fixes #518

- [ ] bump nanomsg once its released nanomsg/nanomsg#1111
- [ ] fix CI (move to GitHub Actions except for FreeBSD)