### PR TITLE
Mark ReportHook & ParameterizedTest as used

### DIFF
--- a/include/criterion/internal/hooks.h
+++ b/include/criterion/internal/hooks.h
@@ -74,6 +74,7 @@
 
 #define CR_REPORT_HOOK_IMPL(Kind)                     \
     CR_HOOK_PROTOTYPE_(CR_HOOK_PARAM_TYPE(Kind));     \
+    CR_ATTRIBUTE(used)                                \
     CR_SECTION_(CR_HOOK_SECTION_STRINGIFY(Kind))      \
     f_report_hook CR_HOOK_IDENTIFIER_(func) =         \
             (f_report_hook) CR_HOOK_IDENTIFIER_(impl) \

--- a/include/criterion/internal/parameterized.h
+++ b/include/criterion/internal/parameterized.h
@@ -97,6 +97,7 @@ struct criterion_test_params {
         CR_IDENTIFIER_(Category,  Name, jmp),                                \
         &CR_IDENTIFIER_(Category, Name, extra)                               \
     };                                                                       \
+    CR_ATTRIBUTE(used)                                                       \
     CR_SECTION_("cr_tst")                                                    \
     struct criterion_test *CR_IDENTIFIER_(Category, Name, ptr)               \
         = &CR_IDENTIFIER_(Category, Name, meta) CR_SECTION_SUFFIX_;          \


### PR DESCRIPTION
With criterion 2.4.3, I tried running the cram tests on an x86_64 Fedora 43 machine.  The parameterized and report tests failed due to missing output.  In both cases, the linker had discarded the test code while building the executable.  This PR adds `used` attributes to prevent that from happening.  With this change, all of the cram tests pass on my machine.
