### PR TITLE
cli: add --default-timeout option for tests with no explicit timeout

### DIFF
--- a/doc/env.rst
+++ b/doc/env.rst
@@ -20,7 +20,10 @@ Command line arguments
   a number of jobs ideal for your hardware configuration.
 * ``--filter [PATTERN]``: Run tests whose string identifier matches
   the given shell wildcard pattern (see dedicated section below). (\*nix only)
-* ``--timeout [TIMEOUT]``: Set a timeout (in seconds) for all tests
+* ``--timeout [TIMEOUT]``: Cap the timeout (in seconds) for all tests,
+  overriding any per-test value that exceeds it.
+* ``--default-timeout [TIMEOUT]``: Set a fallback timeout (in seconds)
+  applied only to tests with no timeout set.
 * ``--debug[=debugger]``: Run tests with a debugging server attached.
   ``debugger`` can be 'gdb', 'lldb', or 'windbg' (windows only).
 * ``--debug-transport [TRANSPORT]``: Make the debugging server use the

--- a/include/criterion/options.h
+++ b/include/criterion/options.h
@@ -184,6 +184,15 @@ struct criterion_options {
     double timeout;
 
     /**
+     *  A default timeout applied to each test that has no timeout set, in seconds.
+     *
+     *  If the value is non-positive, no default is applied.
+     *
+     *  default: 0
+     */
+    double default_timeout;
+
+    /**
      * Fully report statistics from test workers, including those that are
      * not reported by default (like passing assertions).
      *

--- a/src/core/runner_coroutine.c
+++ b/src/core/runner_coroutine.c
@@ -344,6 +344,8 @@ static bxf_instance *run_test(struct run_next_context *ctx,
         timeout = ctx->test->data->timeout;
     if (criterion_options.timeout > 0 && timeout > criterion_options.timeout)
         timeout = criterion_options.timeout;
+    if (timeout <= 0 && criterion_options.default_timeout > 0)
+        timeout = criterion_options.default_timeout;
 
     sp.iquotas.runtime = timeout;
 

--- a/src/entry/params.c
+++ b/src/entry/params.c
@@ -70,8 +70,12 @@
     "name of the source file on a failure\n"                \
     "    --filter [PATTERN]: run tests matching the "       \
     "given pattern\n"                                       \
-    "    --timeout [TIMEOUT]: set a timeout (in seconds) "  \
-    "for all tests\n"                                       \
+    "    --timeout [TIMEOUT]: cap the timeout (in "         \
+    "seconds) for all tests, overriding any per-test "      \
+    "value that exceeds it\n"                               \
+    "    --default-timeout [TIMEOUT]: set a fallback "      \
+    "timeout (in seconds) applied only to tests with "      \
+    "no timeout set\n"                                      \
     "    --tap[=FILE]: writes TAP report in FILE "          \
     "(no file or \"-\" means stderr)\n"                     \
     "    --xml[=FILE]: writes XML report in FILE "          \
@@ -264,6 +268,7 @@ CR_API int criterion_handle_args(int argc, char *argv[],
         { "ascii",           no_argument,       0, 'k' },
         { "jobs",            required_argument, 0, 'j' },
         { "timeout",         required_argument, 0, 't' },
+        { "default-timeout", required_argument, 0, 'g' },
         { "fail-fast",       no_argument,       0, 'f' },
         { "short-filename",  no_argument,       0, 'S' },
         { "single",          required_argument, 0, 's' },
@@ -394,6 +399,7 @@ CR_API int criterion_handle_args(int argc, char *argv[],
             case 'q': quiet = true; break;
 
             case 't': criterion_options.timeout = atof(optarg); break;
+            case 'g': criterion_options.default_timeout = atof(optarg); break;
 
             case 'd':
                 if (!parse_dbg(optarg))

--- a/test/cram/help.t
+++ b/test/cram/help.t
@@ -16,7 +16,8 @@ Display the help message
       --ascii: don't use fancy unicode symbols or colors in the output
       -S or --short-filename: only display the base name of the source file on a failure
       --filter [PATTERN]: run tests matching the given pattern
-      --timeout [TIMEOUT]: set a timeout (in seconds) for all tests
+      --timeout [TIMEOUT]: cap the timeout (in seconds) for all tests, overriding any per-test value that exceeds it
+      --default-timeout [TIMEOUT]: set a fallback timeout (in seconds) applied only to tests with no timeout set
       --tap[=FILE]: writes TAP report in FILE (no file or "-" means stderr)
       --xml[=FILE]: writes XML report in FILE (no file or "-" means stderr)
       --json[=FILE]: writes JSON report in FILE (no file or "-" means stderr)
@@ -49,7 +50,8 @@ C++ equivalents
       --ascii: don't use fancy unicode symbols or colors in the output
       -S or --short-filename: only display the base name of the source file on a failure
       --filter [PATTERN]: run tests matching the given pattern
-      --timeout [TIMEOUT]: set a timeout (in seconds) for all tests
+      --timeout [TIMEOUT]: cap the timeout (in seconds) for all tests, overriding any per-test value that exceeds it
+      --default-timeout [TIMEOUT]: set a fallback timeout (in seconds) applied only to tests with no timeout set
       --tap[=FILE]: writes TAP report in FILE (no file or "-" means stderr)
       --xml[=FILE]: writes XML report in FILE (no file or "-" means stderr)
       --json[=FILE]: writes JSON report in FILE (no file or "-" means stderr)

--- a/test/cram/timeout.t
+++ b/test/cram/timeout.t
@@ -1,0 +1,10 @@
+--default-timeout applies to tests with no explicit timeout
+
+  $ default-timeout.c.bin --default-timeout 1 --filter='timeout/no_timeout_set'
+  \[FAIL\] timeout::no_timeout_set: Timed out. \([0-9.]*s\) (re)
+  [====] Synthesis: Tested: 1 | Passing: 0 | Failing: 1 | Crashing: 0 
+
+--default-timeout does not override an explicit per-test timeout
+
+  $ default-timeout.c.bin --default-timeout 1 --filter='timeout/explicit_not_overridden'
+  [====] Synthesis: Tested: 1 | Passing: 1 | Failing: 0 | Crashing: 0 

--- a/test/full/default-timeout.c
+++ b/test/full/default-timeout.c
@@ -1,0 +1,18 @@
+#include <criterion/criterion.h>
+
+#ifdef _WIN32
+# include <windows.h>
+# define sleep(x)    Sleep(x * 1000)
+#else
+# include <unistd.h>
+#endif
+
+/* No .timeout set, should be killed when --default-timeout is passed. */
+Test(timeout, no_timeout_set) {
+    sleep(10);
+}
+
+/* Explicit .timeout = 5, --default-timeout 1 must not override it. */
+Test(timeout, explicit_not_overridden, .timeout = 5.) {
+    sleep(2);
+}

--- a/test/full/meson.build
+++ b/test/full/meson.build
@@ -28,6 +28,10 @@ if has_cxx
 	endif
 endif
 
+executable('default-timeout.c.bin', 'default-timeout.c',
+		include_directories: [criterion_api],
+		link_with: libcriterion.get_shared_lib())
+
 foreach tst : full_tests
 	e = executable(tst + '.bin', tst,
 			include_directories: [criterion_api],


### PR DESCRIPTION
This PR introduces a new `--default-timeout` CLI option (and its corresponding `criterion_options.default_timeout` field) that applies a fallback timeout to any test that has no timeout set, neither directly on the test nor inherited from its suite.

The existing `--timeout` option acts as a hard cap: it overrides every test's timeout downward if the test's own timeout exceeds the cap. `--default-timeout` fills the complementary gap: it only kicks in when no timeout would otherwise apply, leaving explicitly-timed tests completely untouched.

This would also somewhat resolve #279

## Timeout resolution order (after this PR)

1. Suite timeout (if set)
2. Per-test `.timeout` (overrides suite)
3. `--default-timeout` applied only when the result of steps 1–2 is `<= 0`
4. `--timeout` cap applied only when the result so far exceeds the cap

## Code style notes

Uncrustify was run over the touched files. Two issues came up:

- **Pre-existing errors in untouched files.** Uncrustify reported style violations in files not modified by this PR. Those were left alone to keep the diff focused and avoid muddying the review with unrelated formatting churn.

- **Backslash alignment in the `USAGE` macro (`src/entry/params.c`).** Uncrustify suggested de-aligning the continuation backslashes added for the new `--default-timeout` line. The rest of the macro uses aligned backslashes as an intentional style choice, so the new lines were written to match the surrounding code rather than follow the tool's suggestion.

## Open questions / uncertainties

### Location of the new tests

The cram test (`test/cram/timeout.t`) references `default-timeout.c.bin` by name, which is only built when the full test suite is configured. It is unclear whether this file belongs under `test/cram/` (which typically contains self-contained script tests) or whether it would be better placed alongside the full-test fixtures it depends on, or driven from `test/full/meson.build` directly.

### Help message clarity for `--timeout` vs `--default-timeout`

The current help strings are:

```
--timeout [TIMEOUT]: set a timeout (in seconds) for all tests
--default-timeout [TIMEOUT]: set a default timeout (in seconds) for tests with no explicit timeout
```

These may not make the semantic difference obvious enough to end users, since "for all tests" could be read as "applies universally" without conveying that it acts as a cap. A clearer phrasing might be something like:

```
--timeout [TIMEOUT]: cap the timeout (in seconds) for all tests, overriding any per-test value that exceeds it
--default-timeout [TIMEOUT]: set a fallback timeout (in seconds) applied only to tests with no timeout set
```