### PR TITLE
alloc: do not use deprecated std::allocator types

### DIFF
--- a/include/criterion/alloc.h
+++ b/include/criterion/alloc.h
@@ -270,7 +270,7 @@ struct allocator {
     inline pointer address(reference r) { return &r; }
     inline const_pointer address(const_reference r) { return &r; }
 
-    inline pointer allocate(size_type cnt, const std::allocator<void>::value_type * = 0)
+    inline pointer allocate(size_type cnt, const void * = 0)
     {
         return reinterpret_cast<pointer>(cr_malloc(cnt * sizeof (T)));
     }


### PR DESCRIPTION
std::allocator is deprecated in C++17, and has been removed from C++20.